### PR TITLE
Set json to true in default config - Closes #539

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -2,7 +2,7 @@
 	"name": "Lisk Commander",
 	"version": "1.0.0",
 	"delimiter": "lisk",
-	"json": false,
+	"json": true,
 	"api": {
 		"nodes": [],
 		"network": "main"


### PR DESCRIPTION
### What was the problem?

JSON was set to false in the default config, but is probably used more often than table output.

### How did I fix it?

Set JSON to true in default config.

### How to test it?

Delete your config file and start lisk-commander. Your output should be in JSON.

### Review checklist

* The PR solves #539 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
