### PR TITLE
Change version check to be less strict - Closes #565

### DIFF
--- a/bin/lisk
+++ b/bin/lisk
@@ -38,7 +38,7 @@ function exit(code) {
 }
 
 if (!semver.satisfies(process.version, packageJSON.engines.node)) {
-	console.error('\x1b[31m', `ERROR: Requires Node.js version ${semver.clean(packageJSON.engines.node)}, but was started with version ${semver.clean(process.version)}.`, '\x1b[0m');
+	console.error('\x1b[31m', `ERROR: Requires Node.js version ${packageJSON.engines.node}, but was started with version ${semver.clean(process.version)}.`, '\x1b[0m');
 	exit();
 }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"url": "https://github.com/LiskHQ/lisk-commander/issues"
 	},
 	"engines": {
-		"node": "=6.14.1",
+		"node": ">=6.12 <=6.14",
 		"npm": "=3.10.10"
 	},
 	"directories": {


### PR DESCRIPTION
### What was the problem?
Version check to run lisk-commander was too strict

### How did I fix it?
Change the version check up to minor version, and widen the range.

### How to test it?
```
nvm use 6.11
./bin/lisk
nvm use 6.12
./bin/lisk
nvm use 6.14.3
./bin/lisk
```

### Review checklist

* The PR solves #565 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
