### PR TITLE
Migrate passphrase command - Closes #561

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 				"description": "Displays help."
 			},
 			"passphrase": {
-				"description": "Provides cryptographic utility functions for passphrases."
+				"description": "Commands relating to Lisk passphrases."
 			},
 			"warranty": {
 				"description": "Displays warranty notice."

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
 			"help": {
 				"description": "Displays help."
 			},
+			"passphrase": {
+				"description": "Provides cryptographic utility functions for passphrases."
+			},
 			"warranty": {
 				"description": "Displays warranty notice."
 			}

--- a/src/commands/passphrase/decrypt.js
+++ b/src/commands/passphrase/decrypt.js
@@ -1,0 +1,86 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2017–2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { flags as flagParser } from '@oclif/command';
+import BaseCommand from '../../base';
+import cryptography from '../../utils/cryptography';
+import { ValidationError } from '../../utils/error';
+import commonOptions from '../../utils/options';
+import getInputsFromSources, {
+	getFirstLineFromString,
+} from '../../utils/input';
+
+const passphraseOptionDescription = `Specifies a source for providing an encrypted passphrase to the command. If a string is provided directly as an argument, this option will be ignored. The encrypted passphrase must be provided via an argument or via this option. Sources must be one of \`file\` or \`stdin\`. In the case of \`file\`, a corresponding identifier must also be provided.
+
+	Note: if both an encrypted passphrase and the password are passed via stdin, the password must be the first line.
+
+	Examples:
+		- --passphrase file:/path/to/my/encrypted_passphrase.txt (takes the first line only)
+		- --passphrase stdin (takes the first line only)
+`;
+
+const processInputs = encryptedPassphrase => ({ password, data }) =>
+	cryptography.decryptPassphrase({
+		encryptedPassphrase: encryptedPassphrase || getFirstLineFromString(data),
+		password,
+	});
+
+export default class DecryptCommand extends BaseCommand {
+	async run() {
+		const {
+			args: { encryptedPassphrase },
+			flags: { passphrase: passphraseSource, password: passwordSource },
+		} = this.parse(DecryptCommand);
+
+		if (!encryptedPassphrase && !passphraseSource) {
+			throw new ValidationError('No encrypted passphrase was provided.');
+		}
+		const inputs = await getInputsFromSources({
+			password: {
+				source: passwordSource,
+			},
+			data: encryptedPassphrase
+				? null
+				: {
+						source: passphraseSource,
+					},
+		});
+		const result = processInputs(encryptedPassphrase)(inputs);
+		this.print(result);
+	}
+}
+
+DecryptCommand.args = [
+	{
+		name: 'encryptedPassphrase',
+		description: 'Encrypted passphrase to decrypt.',
+	},
+];
+
+DecryptCommand.flags = {
+	...BaseCommand.flags,
+	password: flagParser.string(commonOptions.password),
+	passphrase: flagParser.string({
+		description: passphraseOptionDescription,
+	}),
+};
+
+DecryptCommand.description = `
+Decrypts your secret passphrase using a password using the initialisation vector (IV) which was provided at the time of encryption.
+`;
+
+DecryptCommand.examples = [
+	'passphrase:decrypt "salt=xxx&cipherText=xxx&iv=xxx&tag=xxx&version=1"',
+];

--- a/src/commands/passphrase/decrypt.js
+++ b/src/commands/passphrase/decrypt.js
@@ -14,10 +14,10 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
+import { cryptography } from 'lisk-elements';
 import BaseCommand from '../../base';
-import cryptography from '../../utils/cryptography';
 import { ValidationError } from '../../utils/error';
-import commonOptions from '../../utils/options';
+import commonFlags from '../../utils/flags';
 import getInputsFromSources, {
 	getFirstLineFromString,
 } from '../../utils/input';
@@ -31,11 +31,16 @@ const passphraseOptionDescription = `Specifies a source for providing an encrypt
 		- --passphrase stdin (takes the first line only)
 `;
 
-const processInputs = encryptedPassphrase => ({ password, data }) =>
-	cryptography.decryptPassphrase({
-		encryptedPassphrase: encryptedPassphrase || getFirstLineFromString(data),
+const processInputs = encryptedPassphrase => ({ password, data }) => {
+	const encryptedPassphraseObject = cryptography.parseEncryptedPassphrase(
+		encryptedPassphrase || getFirstLineFromString(data),
+	);
+	const passphrase = cryptography.decryptPassphraseWithPassword(
+		encryptedPassphraseObject,
 		password,
-	});
+	);
+	return { passphrase };
+};
 
 export default class DecryptCommand extends BaseCommand {
 	async run() {
@@ -71,7 +76,7 @@ DecryptCommand.args = [
 
 DecryptCommand.flags = {
 	...BaseCommand.flags,
-	password: flagParser.string(commonOptions.password),
+	password: flagParser.string(commonFlags.password),
 	passphrase: flagParser.string({
 		description: passphraseOptionDescription,
 	}),

--- a/src/commands/passphrase/decrypt.js
+++ b/src/commands/passphrase/decrypt.js
@@ -83,9 +83,9 @@ DecryptCommand.flags = {
 };
 
 DecryptCommand.description = `
-Decrypts your secret passphrase using a password using the initialisation vector (IV) which was provided at the time of encryption.
+Decrypts your secret passphrase using the password which was provided at the time of encryption.
 `;
 
 DecryptCommand.examples = [
-	'passphrase:decrypt "salt=xxx&cipherText=xxx&iv=xxx&tag=xxx&version=1"',
+	'passphrase:decrypt "iterations=1000000&cipherText=9b1c60&iv=5c8843f52ed3c0f2aa0086b0&salt=2240b7f1aa9c899894e528cf5b600e9c&tag=23c01112134317a63bcf3d41ea74e83b&version=1"',
 ];

--- a/src/commands/passphrase/encrypt.js
+++ b/src/commands/passphrase/encrypt.js
@@ -1,0 +1,71 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2017–2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { flags as flagParser } from '@oclif/command';
+import BaseCommand from '../../base';
+import commonOptions from '../../utils/options';
+import getInputsFromSources from '../../utils/input';
+import cryptography from '../../utils/cryptography';
+
+const outputPublicKeyOptionDescription =
+	'Includes the public key in the output. This option is provided for the convenience of node operators.';
+
+const processInputs = outputPublicKey => ({ passphrase, password }) => {
+	const cipherAndIv = cryptography.encryptPassphrase({ passphrase, password });
+	return outputPublicKey
+		? Object.assign({}, cipherAndIv, {
+				publicKey: cryptography.getKeys(passphrase).publicKey,
+			})
+		: cipherAndIv;
+};
+
+export default class EncryptCommand extends BaseCommand {
+	async run() {
+		const {
+			flags: {
+				passphrase: passphraseSource,
+				password: passwordSource,
+				outputPublicKey,
+			},
+		} = this.parse(EncryptCommand);
+		const inputs = await getInputsFromSources({
+			passphrase: {
+				source: passphraseSource,
+				repeatPrompt: true,
+			},
+			password: {
+				source: passwordSource,
+				repeatPrompt: true,
+			},
+		});
+		const result = processInputs(outputPublicKey)(inputs);
+		this.print(result);
+	}
+}
+
+EncryptCommand.flags = {
+	...BaseCommand.flags,
+	password: flagParser.string(commonOptions.password),
+	passphrase: flagParser.string(commonOptions.passphrase),
+	outputPublicKey: flagParser.boolean({
+		description: outputPublicKeyOptionDescription,
+	}),
+};
+
+EncryptCommand.description = `
+Encrypts your secret passphrase under a password.
+`;
+
+EncryptCommand.examples = ['passphrase:encrypt'];

--- a/src/commands/passphrase/encrypt.js
+++ b/src/commands/passphrase/encrypt.js
@@ -30,12 +30,12 @@ const processInputs = outputPublicKey => ({ passphrase, password }) => {
 	const encryptedPassphrase = cryptography.stringifyEncryptedPassphrase(
 		encryptedPassphraseObject,
 	);
-	const cipherAndIv = { encryptedPassphrase };
 	return outputPublicKey
-		? Object.assign({}, cipherAndIv, {
+		? {
+				encryptedPassphrase,
 				publicKey: cryptography.getKeys(passphrase).publicKey,
-			})
-		: cipherAndIv;
+			}
+		: { encryptedPassphrase };
 };
 
 export default class EncryptCommand extends BaseCommand {

--- a/src/commands/passphrase/encrypt.js
+++ b/src/commands/passphrase/encrypt.js
@@ -14,16 +14,23 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
+import { cryptography } from 'lisk-elements';
 import BaseCommand from '../../base';
-import commonOptions from '../../utils/options';
+import commonFlags from '../../utils/flags';
 import getInputsFromSources from '../../utils/input';
-import cryptography from '../../utils/cryptography';
 
 const outputPublicKeyOptionDescription =
 	'Includes the public key in the output. This option is provided for the convenience of node operators.';
 
 const processInputs = outputPublicKey => ({ passphrase, password }) => {
-	const cipherAndIv = cryptography.encryptPassphrase({ passphrase, password });
+	const encryptedPassphraseObject = cryptography.encryptPassphraseWithPassword(
+		passphrase,
+		password,
+	);
+	const encryptedPassphrase = cryptography.stringifyEncryptedPassphrase(
+		encryptedPassphraseObject,
+	);
+	const cipherAndIv = { encryptedPassphrase };
 	return outputPublicKey
 		? Object.assign({}, cipherAndIv, {
 				publicKey: cryptography.getKeys(passphrase).publicKey,
@@ -57,8 +64,8 @@ export default class EncryptCommand extends BaseCommand {
 
 EncryptCommand.flags = {
 	...BaseCommand.flags,
-	password: flagParser.string(commonOptions.password),
-	passphrase: flagParser.string(commonOptions.passphrase),
+	password: flagParser.string(commonFlags.password),
+	passphrase: flagParser.string(commonFlags.passphrase),
 	outputPublicKey: flagParser.boolean({
 		description: outputPublicKeyOptionDescription,
 	}),

--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -82,7 +82,7 @@ const flags = {
 		description: secondPassphraseDescription,
 	},
 	password: {
-		char: '2',
+		char: 'w',
 		description: passwordDescription,
 	},
 	unvotes: {

--- a/test/commands/passphrase/decrypt.test.js
+++ b/test/commands/passphrase/decrypt.test.js
@@ -1,0 +1,48 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2017–2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { expect, test } from '../../test';
+import * as config from '../../../src/utils/config';
+import * as print from '../../../src/utils/print';
+
+describe('config:show', () => {
+	const defaultConfig = {
+		api: {
+			network: 'main',
+			nodes: ['http://localhost:4000'],
+		},
+	};
+
+	const printMethodStub = sandbox.stub();
+	const setupStub = test
+		.stub(print, 'default', sandbox.stub().returns(printMethodStub))
+		.stub(config, 'getConfig', sandbox.stub().returns(defaultConfig));
+
+	setupStub
+		.stdout()
+		.command(['config:show'])
+		.it('should call print with the user config', () => {
+			expect(print.default).to.be.called;
+			return expect(printMethodStub).to.be.calledWithExactly(defaultConfig);
+		});
+
+	setupStub
+		.stdout()
+		.command(['config:show', '--json', '--pretty'])
+		.it('should call print with json', () => {
+			expect(print.default).to.be.calledWith({ json: true, pretty: true });
+			return expect(printMethodStub).to.be.calledWithExactly(defaultConfig);
+		});
+});

--- a/test/commands/passphrase/decrypt.test.js
+++ b/test/commands/passphrase/decrypt.test.js
@@ -22,7 +22,8 @@ import * as getInputsFromSources from '../../../src/utils/input';
 describe('passphrase:decrypt', () => {
 	const defaultEncryptedPassphrase =
 		'salt=d3887df959ed2bfe5961a6831da6e177&cipherText=1c08a1&iv=096ede534df9092fd4523ec7&tag=2a055e1c860b3ef76084a6c9aca68ce9&version=1';
-	const passphrase = '123';
+	const passphrase =
+		'enemy pill squeeze gold spoil aisle awake thumb congress false box wagon';
 	const encryptedPassphraseObject = {
 		salt: 'salt',
 		cipherText: 'cipherText',
@@ -31,7 +32,7 @@ describe('passphrase:decrypt', () => {
 		version: 1,
 	};
 	const defaultInputs = {
-		password: '456',
+		password: 'LbYpLpV9Wpec6ux8',
 		data: `${defaultEncryptedPassphrase}\nshould not be used`,
 	};
 
@@ -54,23 +55,22 @@ describe('passphrase:decrypt', () => {
 				getInputsFromSources,
 				'default',
 				sandbox.stub().resolves(defaultInputs),
-			);
+			)
+			.stdout();
 
 	describe('passphrase:decrypt', () => {
 		setupTest()
-			.stdout()
 			.command(['passphrase:decrypt'])
-			.catch(error =>
-				expect(error.message).to.contain(
+			.catch(error => {
+				return expect(error.message).to.contain(
 					'No encrypted passphrase was provided.',
-				),
-			)
+				);
+			})
 			.it('should throw an error');
 	});
 
 	describe('passphrase:decrypt encryptedPassphrase', () => {
 		setupTest()
-			.stdout()
 			.command(['passphrase:decrypt', defaultEncryptedPassphrase])
 			.it('should decrypt passphrase with arg', () => {
 				expect(getInputsFromSources.default).to.be.calledWithExactly({
@@ -95,7 +95,6 @@ describe('passphrase:decrypt', () => {
 	describe('passphrase:decrypt --passphrase=file:./path/to/encrypted_passphrase.txt', () => {
 		const passphraseSource = 'file:./path/to/encrypted_passphrase.txt';
 		setupTest()
-			.stdout()
 			.command(['passphrase:decrypt', `--passphrase=${passphraseSource}`])
 			.it('should decrypt passphrase with passphrase flag', () => {
 				expect(getInputsFromSources.default).to.be.calledWithExactly({
@@ -119,21 +118,20 @@ describe('passphrase:decrypt', () => {
 			});
 	});
 
-	describe('passphrase:decrypt --passphrase=filePath --password=pass:456', () => {
+	describe('passphrase:decrypt --passphrase=filePath --password=pass:LbYpLpV9Wpec6ux8', () => {
 		const passphraseSource = 'file:./path/to/encrypted_passphrase.txt';
 		setupTest()
-			.stdout()
 			.command([
 				'passphrase:decrypt',
 				`--passphrase=${passphraseSource}`,
-				'--password=pass:456',
+				'--password=pass:LbYpLpV9Wpec6ux8',
 			])
 			.it(
 				'should decrypt passphrase with passphrase flag and password flag',
 				() => {
 					expect(getInputsFromSources.default).to.be.calledWithExactly({
 						password: {
-							source: 'pass:456',
+							source: 'pass:LbYpLpV9Wpec6ux8',
 						},
 						data: {
 							source: passphraseSource,

--- a/test/commands/passphrase/decrypt.test.js
+++ b/test/commands/passphrase/decrypt.test.js
@@ -13,24 +13,22 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { expect, test } from '../../test';
+import { expect, test } from '@oclif/test';
+import { cryptography } from 'lisk-elements';
 import * as config from '../../../src/utils/config';
 import * as print from '../../../src/utils/print';
-import cryptography from '../../../src/utils/cryptography';
 import * as getInputsFromSources from '../../../src/utils/input';
 
 describe('passphrase:decrypt', () => {
-	const defaultConfig = {
-		api: {
-			network: 'main',
-			nodes: ['http://localhost:4000'],
-		},
-	};
-
 	const defaultEncryptedPassphrase =
 		'salt=d3887df959ed2bfe5961a6831da6e177&cipherText=1c08a1&iv=096ede534df9092fd4523ec7&tag=2a055e1c860b3ef76084a6c9aca68ce9&version=1';
-	const passphrase = {
-		passphrase: '123',
+	const passphrase = '123';
+	const encryptedPassphraseObject = {
+		salt: 'salt',
+		cipherText: 'cipherText',
+		iv: 'iv',
+		tag: 'tag',
+		version: 1,
 	};
 	const defaultInputs = {
 		password: '456',
@@ -40,8 +38,17 @@ describe('passphrase:decrypt', () => {
 	const printMethodStub = sandbox.stub();
 	const setupStub = test
 		.stub(print, 'default', sandbox.stub().returns(printMethodStub))
-		.stub(config, 'getConfig', sandbox.stub().returns(defaultConfig))
-		.stub(cryptography, 'decryptPassphrase', sandbox.stub().returns(passphrase))
+		.stub(config, 'getConfig', sandbox.stub().returns({}))
+		.stub(
+			cryptography,
+			'parseEncryptedPassphrase',
+			sandbox.stub().returns(encryptedPassphraseObject),
+		)
+		.stub(
+			cryptography,
+			'decryptPassphraseWithPassword',
+			sandbox.stub().returns(passphrase),
+		)
 		.stub(
 			getInputsFromSources,
 			'default',
@@ -71,11 +78,16 @@ describe('passphrase:decrypt', () => {
 					},
 					data: null,
 				});
-				expect(cryptography.decryptPassphrase).to.be.calledWithExactly({
-					encryptedPassphrase: defaultEncryptedPassphrase,
-					password: defaultInputs.password,
-				});
-				return expect(printMethodStub).to.be.calledWithExactly(passphrase);
+				expect(cryptography.parseEncryptedPassphrase).to.be.calledWithExactly(
+					defaultEncryptedPassphrase,
+				);
+				expect(
+					cryptography.decryptPassphraseWithPassword,
+				).to.be.calledWithExactly(
+					encryptedPassphraseObject,
+					defaultInputs.password,
+				);
+				return expect(printMethodStub).to.be.calledWithExactly({ passphrase });
 			});
 	});
 
@@ -93,11 +105,16 @@ describe('passphrase:decrypt', () => {
 						source: passphraseSource,
 					},
 				});
-				expect(cryptography.decryptPassphrase).to.be.calledWithExactly({
-					encryptedPassphrase: defaultEncryptedPassphrase,
-					password: defaultInputs.password,
-				});
-				return expect(printMethodStub).to.be.calledWithExactly(passphrase);
+				expect(cryptography.parseEncryptedPassphrase).to.be.calledWithExactly(
+					defaultEncryptedPassphrase,
+				);
+				expect(
+					cryptography.decryptPassphraseWithPassword,
+				).to.be.calledWithExactly(
+					encryptedPassphraseObject,
+					defaultInputs.password,
+				);
+				return expect(printMethodStub).to.be.calledWithExactly({ passphrase });
 			});
 	});
 
@@ -121,11 +138,18 @@ describe('passphrase:decrypt', () => {
 							source: passphraseSource,
 						},
 					});
-					expect(cryptography.decryptPassphrase).to.be.calledWithExactly({
-						encryptedPassphrase: defaultEncryptedPassphrase,
-						password: defaultInputs.password,
+					expect(cryptography.parseEncryptedPassphrase).to.be.calledWithExactly(
+						defaultEncryptedPassphrase,
+					);
+					expect(
+						cryptography.decryptPassphraseWithPassword,
+					).to.be.calledWithExactly(
+						encryptedPassphraseObject,
+						defaultInputs.password,
+					);
+					return expect(printMethodStub).to.be.calledWithExactly({
+						passphrase,
 					});
-					return expect(printMethodStub).to.be.calledWithExactly(passphrase);
 				},
 			);
 	});

--- a/test/commands/passphrase/decrypt.test.js
+++ b/test/commands/passphrase/decrypt.test.js
@@ -36,27 +36,28 @@ describe('passphrase:decrypt', () => {
 	};
 
 	const printMethodStub = sandbox.stub();
-	const setupStub = test
-		.stub(print, 'default', sandbox.stub().returns(printMethodStub))
-		.stub(config, 'getConfig', sandbox.stub().returns({}))
-		.stub(
-			cryptography,
-			'parseEncryptedPassphrase',
-			sandbox.stub().returns(encryptedPassphraseObject),
-		)
-		.stub(
-			cryptography,
-			'decryptPassphraseWithPassword',
-			sandbox.stub().returns(passphrase),
-		)
-		.stub(
-			getInputsFromSources,
-			'default',
-			sandbox.stub().resolves(defaultInputs),
-		);
+	const setupTest = () =>
+		test
+			.stub(print, 'default', sandbox.stub().returns(printMethodStub))
+			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				cryptography,
+				'parseEncryptedPassphrase',
+				sandbox.stub().returns(encryptedPassphraseObject),
+			)
+			.stub(
+				cryptography,
+				'decryptPassphraseWithPassword',
+				sandbox.stub().returns(passphrase),
+			)
+			.stub(
+				getInputsFromSources,
+				'default',
+				sandbox.stub().resolves(defaultInputs),
+			);
 
 	describe('passphrase:decrypt', () => {
-		setupStub
+		setupTest()
 			.stdout()
 			.command(['passphrase:decrypt'])
 			.catch(error =>
@@ -68,7 +69,7 @@ describe('passphrase:decrypt', () => {
 	});
 
 	describe('passphrase:decrypt encryptedPassphrase', () => {
-		setupStub
+		setupTest()
 			.stdout()
 			.command(['passphrase:decrypt', defaultEncryptedPassphrase])
 			.it('should decrypt passphrase with arg', () => {
@@ -93,7 +94,7 @@ describe('passphrase:decrypt', () => {
 
 	describe('passphrase:decrypt --passphrase=file:./path/to/encrypted_passphrase.txt', () => {
 		const passphraseSource = 'file:./path/to/encrypted_passphrase.txt';
-		setupStub
+		setupTest()
 			.stdout()
 			.command(['passphrase:decrypt', `--passphrase=${passphraseSource}`])
 			.it('should decrypt passphrase with passphrase flag', () => {
@@ -120,7 +121,7 @@ describe('passphrase:decrypt', () => {
 
 	describe('passphrase:decrypt --passphrase=filePath --password=pass:456', () => {
 		const passphraseSource = 'file:./path/to/encrypted_passphrase.txt';
-		setupStub
+		setupTest()
 			.stdout()
 			.command([
 				'passphrase:decrypt',

--- a/test/commands/passphrase/encrypt.test.js
+++ b/test/commands/passphrase/encrypt.test.js
@@ -1,0 +1,48 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2017–2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { expect, test } from '../../test';
+import * as config from '../../../src/utils/config';
+import * as print from '../../../src/utils/print';
+
+describe('config:show', () => {
+	const defaultConfig = {
+		api: {
+			network: 'main',
+			nodes: ['http://localhost:4000'],
+		},
+	};
+
+	const printMethodStub = sandbox.stub();
+	const setupStub = test
+		.stub(print, 'default', sandbox.stub().returns(printMethodStub))
+		.stub(config, 'getConfig', sandbox.stub().returns(defaultConfig));
+
+	setupStub
+		.stdout()
+		.command(['config:show'])
+		.it('should call print with the user config', () => {
+			expect(print.default).to.be.called;
+			return expect(printMethodStub).to.be.calledWithExactly(defaultConfig);
+		});
+
+	setupStub
+		.stdout()
+		.command(['config:show', '--json', '--pretty'])
+		.it('should call print with json', () => {
+			expect(print.default).to.be.calledWith({ json: true, pretty: true });
+			return expect(printMethodStub).to.be.calledWithExactly(defaultConfig);
+		});
+});

--- a/test/commands/passphrase/encrypt.test.js
+++ b/test/commands/passphrase/encrypt.test.js
@@ -16,33 +16,139 @@
 import { expect, test } from '../../test';
 import * as config from '../../../src/utils/config';
 import * as print from '../../../src/utils/print';
+import cryptography from '../../../src/utils/cryptography';
+import * as getInputsFromSources from '../../../src/utils/input';
 
-describe('config:show', () => {
-	const defaultConfig = {
-		api: {
-			network: 'main',
-			nodes: ['http://localhost:4000'],
-		},
+describe('passphrase:encrypt', () => {
+	const defaultEncryptedPassphrase = {
+		encryptedPassphrase:
+			'salt=683425ca06c9ff88a5ab292bb5066dc5&cipherText=4ce151&iv=bfaeef79a466e370e210f3c6&tag=e84bf097b1ec5ae428dd7ed3b4cce522&version=1',
+	};
+	const defaultKeys = {
+		publicKey:
+			'a4465fd76c16fcc458448076372abf1912cc5b150663a64dffefe550f96feadd',
+	};
+	const defaultInputs = {
+		passphrase: '123',
+		password: '456',
 	};
 
 	const printMethodStub = sandbox.stub();
 	const setupStub = test
 		.stub(print, 'default', sandbox.stub().returns(printMethodStub))
-		.stub(config, 'getConfig', sandbox.stub().returns(defaultConfig));
+		.stub(config, 'getConfig', sandbox.stub().returns({}))
+		.stub(cryptography, 'getKey', sandbox.stub().returns(defaultKeys))
+		.stub(
+			cryptography,
+			'encryptPassphrase',
+			sandbox.stub().returns(defaultEncryptedPassphrase),
+		)
+		.stub(
+			getInputsFromSources,
+			'default',
+			sandbox.stub().resolves(defaultInputs),
+		);
 
-	setupStub
-		.stdout()
-		.command(['config:show'])
-		.it('should call print with the user config', () => {
-			expect(print.default).to.be.called;
-			return expect(printMethodStub).to.be.calledWithExactly(defaultConfig);
-		});
+	describe('passphrase:encrypt', () => {
+		setupStub
+			.stdout()
+			.command(['passphrase:encrypt'])
+			.it('should encrypt passphrase', () => {
+				expect(cryptography.encryptPassphrase).to.be.calledWithExactly(
+					defaultInputs,
+				);
+				expect(getInputsFromSources.default).to.be.calledWithExactly({
+					passphrase: {
+						source: undefined,
+						repeatPrompt: true,
+					},
+					password: {
+						source: undefined,
+						repeatPrompt: true,
+					},
+				});
+				return expect(printMethodStub).to.be.calledWithExactly(
+					defaultEncryptedPassphrase,
+				);
+			});
+	});
 
-	setupStub
-		.stdout()
-		.command(['config:show', '--json', '--pretty'])
-		.it('should call print with json', () => {
-			expect(print.default).to.be.calledWith({ json: true, pretty: true });
-			return expect(printMethodStub).to.be.calledWithExactly(defaultConfig);
-		});
+	describe('passphrase:encrypt --outputPublicKey', () => {
+		setupStub
+			.stdout()
+			.command(['passphrase:encrypt', '--outputPublicKey'])
+			.it('should encrypt passphrase and output public key', () => {
+				expect(cryptography.encryptPassphrase).to.be.calledWithExactly(
+					defaultInputs,
+				);
+				expect(getInputsFromSources.default).to.be.calledWithExactly({
+					passphrase: {
+						source: undefined,
+						repeatPrompt: true,
+					},
+					password: {
+						source: undefined,
+						repeatPrompt: true,
+					},
+				});
+				return expect(printMethodStub).to.be.calledWithExactly(
+					Object.assign({}, defaultEncryptedPassphrase, defaultKeys),
+				);
+			});
+	});
+
+	describe('passphrase:encrypt --passphrase=pass:123', () => {
+		setupStub
+			.stdout()
+			.command(['passphrase:encrypt', '--passphrase=pass:123'])
+			.it('should call print with the user config', () => {
+				expect(cryptography.encryptPassphrase).to.be.calledWithExactly(
+					defaultInputs,
+				);
+				expect(getInputsFromSources.default).to.be.calledWithExactly({
+					passphrase: {
+						source: 'pass:123',
+						repeatPrompt: true,
+					},
+					password: {
+						source: undefined,
+						repeatPrompt: true,
+					},
+				});
+				return expect(printMethodStub).to.be.calledWithExactly(
+					defaultEncryptedPassphrase,
+				);
+			});
+	});
+
+	describe('passphrase:encrypt --passphrase=pass:123 --password=pass:456', () => {
+		setupStub
+			.stdout()
+			.command([
+				'passphrase:encrypt',
+				'--passphrase=pass:123',
+				'--password=pass:456',
+			])
+			.it(
+				'should encrypt passphrase from passphrase and password flags',
+				() => {
+					expect(cryptography.encryptPassphrase).to.be.calledWithExactly(
+						defaultInputs,
+					);
+					expect(getInputsFromSources.default).to.be.calledWithExactly({
+						passphrase: {
+							source: 'pass:123',
+							repeatPrompt: true,
+						},
+						password: {
+							source: 'pass:456',
+							repeatPrompt: true,
+						},
+					});
+					return expect(printMethodStub).to.be.calledWithExactly(
+						defaultEncryptedPassphrase,
+					);
+				},
+			);
+	});
 });

--- a/test/commands/passphrase/encrypt.test.js
+++ b/test/commands/passphrase/encrypt.test.js
@@ -24,7 +24,7 @@ describe('passphrase:encrypt', () => {
 		'salt=683425ca06c9ff88a5ab292bb5066dc5&cipherText=4ce151&iv=bfaeef79a466e370e210f3c6&tag=e84bf097b1ec5ae428dd7ed3b4cce522&version=1';
 	const defaultKeys = {
 		publicKey:
-			'a4465fd76c16fcc458448076372abf1912cc5b150663a64dffefe550f96feadd',
+			'337600533a1f734c84b738d5f634c284a80ecc8b92bae4f30c1f22f8fd001e6a',
 	};
 	const encryptedPassphraseObject = {
 		salt: 'salt',
@@ -34,8 +34,9 @@ describe('passphrase:encrypt', () => {
 		version: 1,
 	};
 	const defaultInputs = {
-		passphrase: '123',
-		password: '456',
+		passphrase:
+			'enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+		password: 'LbYpLpV9Wpec6ux8',
 	};
 
 	const printMethodStub = sandbox.stub();
@@ -58,11 +59,11 @@ describe('passphrase:encrypt', () => {
 				getInputsFromSources,
 				'default',
 				sandbox.stub().resolves(defaultInputs),
-			);
+			)
+			.stdout();
 
 	describe('passphrase:encrypt', () => {
 		setupTest()
-			.stdout()
 			.command(['passphrase:encrypt'])
 			.it('should encrypt passphrase', () => {
 				expect(
@@ -92,7 +93,6 @@ describe('passphrase:encrypt', () => {
 
 	describe('passphrase:encrypt --outputPublicKey', () => {
 		setupTest()
-			.stdout()
 			.command(['passphrase:encrypt', '--outputPublicKey'])
 			.it('should encrypt passphrase and output public key', () => {
 				expect(
@@ -121,43 +121,48 @@ describe('passphrase:encrypt', () => {
 			});
 	});
 
-	describe('passphrase:encrypt --passphrase=pass:123', () => {
+	describe('passphrase:encrypt --passphrase=pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon', () => {
 		setupTest()
-			.stdout()
-			.command(['passphrase:encrypt', '--passphrase=pass:123'])
-			.it('should call print with the user config', () => {
-				expect(
-					cryptography.encryptPassphraseWithPassword,
-				).to.be.calledWithExactly(
-					defaultInputs.passphrase,
-					defaultInputs.password,
-				);
-				expect(
-					cryptography.stringifyEncryptedPassphrase,
-				).to.be.calledWithExactly(encryptedPassphraseObject);
-				expect(getInputsFromSources.default).to.be.calledWithExactly({
-					passphrase: {
-						source: 'pass:123',
-						repeatPrompt: true,
-					},
-					password: {
-						source: undefined,
-						repeatPrompt: true,
-					},
-				});
-				return expect(printMethodStub).to.be.calledWithExactly({
-					encryptedPassphrase: encryptedPassphraseString,
-				});
-			});
-	});
-
-	describe('passphrase:encrypt --passphrase=pass:123 --password=pass:456', () => {
-		setupTest()
-			.stdout()
 			.command([
 				'passphrase:encrypt',
-				'--passphrase=pass:123',
-				'--password=pass:456',
+				'--passphrase=pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+			])
+			.it(
+				'should encrypt passphrase from passphrase flag and stdout password',
+				() => {
+					expect(
+						cryptography.encryptPassphraseWithPassword,
+					).to.be.calledWithExactly(
+						defaultInputs.passphrase,
+						defaultInputs.password,
+					);
+					expect(
+						cryptography.stringifyEncryptedPassphrase,
+					).to.be.calledWithExactly(encryptedPassphraseObject);
+					expect(getInputsFromSources.default).to.be.calledWithExactly({
+						passphrase: {
+							source:
+								'pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+							repeatPrompt: true,
+						},
+						password: {
+							source: undefined,
+							repeatPrompt: true,
+						},
+					});
+					return expect(printMethodStub).to.be.calledWithExactly({
+						encryptedPassphrase: encryptedPassphraseString,
+					});
+				},
+			);
+	});
+
+	describe('passphrase:encrypt --passphrase=pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon --password=pass:LbYpLpV9Wpec6ux8', () => {
+		setupTest()
+			.command([
+				'passphrase:encrypt',
+				'--passphrase=pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+				'--password=pass:LbYpLpV9Wpec6ux8',
 			])
 			.it(
 				'should encrypt passphrase from passphrase and password flags',
@@ -173,11 +178,12 @@ describe('passphrase:encrypt', () => {
 					).to.be.calledWithExactly(encryptedPassphraseObject);
 					expect(getInputsFromSources.default).to.be.calledWithExactly({
 						passphrase: {
-							source: 'pass:123',
+							source:
+								'pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
 							repeatPrompt: true,
 						},
 						password: {
-							source: 'pass:456',
+							source: 'pass:LbYpLpV9Wpec6ux8',
 							repeatPrompt: true,
 						},
 					});

--- a/test/commands/passphrase/encrypt.test.js
+++ b/test/commands/passphrase/encrypt.test.js
@@ -121,11 +121,11 @@ describe('passphrase:encrypt', () => {
 			});
 	});
 
-	describe('passphrase:encrypt --passphrase=pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon', () => {
+	describe('passphrase:encrypt --passphrase=pass:"enemy pill squeeze gold spoil aisle awake thumb congress false box wagon"', () => {
 		setupTest()
 			.command([
 				'passphrase:encrypt',
-				'--passphrase=pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+				'--passphrase=pass:"enemy pill squeeze gold spoil aisle awake thumb congress false box wagon"',
 			])
 			.it(
 				'should encrypt passphrase from passphrase flag and stdout password',
@@ -142,7 +142,7 @@ describe('passphrase:encrypt', () => {
 					expect(getInputsFromSources.default).to.be.calledWithExactly({
 						passphrase: {
 							source:
-								'pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+								'pass:"enemy pill squeeze gold spoil aisle awake thumb congress false box wagon"',
 							repeatPrompt: true,
 						},
 						password: {
@@ -157,11 +157,11 @@ describe('passphrase:encrypt', () => {
 			);
 	});
 
-	describe('passphrase:encrypt --passphrase=pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon --password=pass:LbYpLpV9Wpec6ux8', () => {
+	describe('passphrase:encrypt --passphrase=pass:"enemy pill squeeze gold spoil aisle awake thumb congress false box wagon" --password=pass:LbYpLpV9Wpec6ux8', () => {
 		setupTest()
 			.command([
 				'passphrase:encrypt',
-				'--passphrase=pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+				'--passphrase=pass:"enemy pill squeeze gold spoil aisle awake thumb congress false box wagon"',
 				'--password=pass:LbYpLpV9Wpec6ux8',
 			])
 			.it(
@@ -179,7 +179,7 @@ describe('passphrase:encrypt', () => {
 					expect(getInputsFromSources.default).to.be.calledWithExactly({
 						passphrase: {
 							source:
-								'pass:enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+								'pass:"enemy pill squeeze gold spoil aisle awake thumb congress false box wagon"',
 							repeatPrompt: true,
 						},
 						password: {

--- a/test/commands/passphrase/encrypt.test.js
+++ b/test/commands/passphrase/encrypt.test.js
@@ -13,20 +13,25 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { expect, test } from '../../test';
+import { expect, test } from '@oclif/test';
+import { cryptography } from 'lisk-elements';
 import * as config from '../../../src/utils/config';
 import * as print from '../../../src/utils/print';
-import cryptography from '../../../src/utils/cryptography';
 import * as getInputsFromSources from '../../../src/utils/input';
 
 describe('passphrase:encrypt', () => {
-	const defaultEncryptedPassphrase = {
-		encryptedPassphrase:
-			'salt=683425ca06c9ff88a5ab292bb5066dc5&cipherText=4ce151&iv=bfaeef79a466e370e210f3c6&tag=e84bf097b1ec5ae428dd7ed3b4cce522&version=1',
-	};
+	const encryptedPassphraseString =
+		'salt=683425ca06c9ff88a5ab292bb5066dc5&cipherText=4ce151&iv=bfaeef79a466e370e210f3c6&tag=e84bf097b1ec5ae428dd7ed3b4cce522&version=1';
 	const defaultKeys = {
 		publicKey:
 			'a4465fd76c16fcc458448076372abf1912cc5b150663a64dffefe550f96feadd',
+	};
+	const encryptedPassphraseObject = {
+		salt: 'salt',
+		cipherText: 'cipherText',
+		iv: 'iv',
+		tag: 'tag',
+		version: 1,
 	};
 	const defaultInputs = {
 		passphrase: '123',
@@ -40,8 +45,13 @@ describe('passphrase:encrypt', () => {
 		.stub(cryptography, 'getKey', sandbox.stub().returns(defaultKeys))
 		.stub(
 			cryptography,
-			'encryptPassphrase',
-			sandbox.stub().returns(defaultEncryptedPassphrase),
+			'encryptPassphraseWithPassword',
+			sandbox.stub().returns(encryptedPassphraseObject),
+		)
+		.stub(
+			cryptography,
+			'stringifyEncryptedPassphrase',
+			sandbox.stub().returns(encryptedPassphraseString),
 		)
 		.stub(
 			getInputsFromSources,
@@ -54,9 +64,15 @@ describe('passphrase:encrypt', () => {
 			.stdout()
 			.command(['passphrase:encrypt'])
 			.it('should encrypt passphrase', () => {
-				expect(cryptography.encryptPassphrase).to.be.calledWithExactly(
-					defaultInputs,
+				expect(
+					cryptography.encryptPassphraseWithPassword,
+				).to.be.calledWithExactly(
+					defaultInputs.passphrase,
+					defaultInputs.password,
 				);
+				expect(
+					cryptography.stringifyEncryptedPassphrase,
+				).to.be.calledWithExactly(encryptedPassphraseObject);
 				expect(getInputsFromSources.default).to.be.calledWithExactly({
 					passphrase: {
 						source: undefined,
@@ -67,9 +83,9 @@ describe('passphrase:encrypt', () => {
 						repeatPrompt: true,
 					},
 				});
-				return expect(printMethodStub).to.be.calledWithExactly(
-					defaultEncryptedPassphrase,
-				);
+				return expect(printMethodStub).to.be.calledWithExactly({
+					encryptedPassphrase: encryptedPassphraseString,
+				});
 			});
 	});
 
@@ -78,9 +94,15 @@ describe('passphrase:encrypt', () => {
 			.stdout()
 			.command(['passphrase:encrypt', '--outputPublicKey'])
 			.it('should encrypt passphrase and output public key', () => {
-				expect(cryptography.encryptPassphrase).to.be.calledWithExactly(
-					defaultInputs,
+				expect(
+					cryptography.encryptPassphraseWithPassword,
+				).to.be.calledWithExactly(
+					defaultInputs.passphrase,
+					defaultInputs.password,
 				);
+				expect(
+					cryptography.stringifyEncryptedPassphrase,
+				).to.be.calledWithExactly(encryptedPassphraseObject);
 				expect(getInputsFromSources.default).to.be.calledWithExactly({
 					passphrase: {
 						source: undefined,
@@ -91,9 +113,10 @@ describe('passphrase:encrypt', () => {
 						repeatPrompt: true,
 					},
 				});
-				return expect(printMethodStub).to.be.calledWithExactly(
-					Object.assign({}, defaultEncryptedPassphrase, defaultKeys),
-				);
+				return expect(printMethodStub).to.be.calledWithExactly({
+					encryptedPassphrase: encryptedPassphraseString,
+					...defaultKeys,
+				});
 			});
 	});
 
@@ -102,9 +125,15 @@ describe('passphrase:encrypt', () => {
 			.stdout()
 			.command(['passphrase:encrypt', '--passphrase=pass:123'])
 			.it('should call print with the user config', () => {
-				expect(cryptography.encryptPassphrase).to.be.calledWithExactly(
-					defaultInputs,
+				expect(
+					cryptography.encryptPassphraseWithPassword,
+				).to.be.calledWithExactly(
+					defaultInputs.passphrase,
+					defaultInputs.password,
 				);
+				expect(
+					cryptography.stringifyEncryptedPassphrase,
+				).to.be.calledWithExactly(encryptedPassphraseObject);
 				expect(getInputsFromSources.default).to.be.calledWithExactly({
 					passphrase: {
 						source: 'pass:123',
@@ -115,9 +144,9 @@ describe('passphrase:encrypt', () => {
 						repeatPrompt: true,
 					},
 				});
-				return expect(printMethodStub).to.be.calledWithExactly(
-					defaultEncryptedPassphrase,
-				);
+				return expect(printMethodStub).to.be.calledWithExactly({
+					encryptedPassphrase: encryptedPassphraseString,
+				});
 			});
 	});
 
@@ -132,9 +161,15 @@ describe('passphrase:encrypt', () => {
 			.it(
 				'should encrypt passphrase from passphrase and password flags',
 				() => {
-					expect(cryptography.encryptPassphrase).to.be.calledWithExactly(
-						defaultInputs,
+					expect(
+						cryptography.encryptPassphraseWithPassword,
+					).to.be.calledWithExactly(
+						defaultInputs.passphrase,
+						defaultInputs.password,
 					);
+					expect(
+						cryptography.stringifyEncryptedPassphrase,
+					).to.be.calledWithExactly(encryptedPassphraseObject);
 					expect(getInputsFromSources.default).to.be.calledWithExactly({
 						passphrase: {
 							source: 'pass:123',
@@ -145,9 +180,9 @@ describe('passphrase:encrypt', () => {
 							repeatPrompt: true,
 						},
 					});
-					return expect(printMethodStub).to.be.calledWithExactly(
-						defaultEncryptedPassphrase,
-					);
+					return expect(printMethodStub).to.be.calledWithExactly({
+						encryptedPassphrase: encryptedPassphraseString,
+					});
 				},
 			);
 	});

--- a/test/commands/passphrase/encrypt.test.js
+++ b/test/commands/passphrase/encrypt.test.js
@@ -39,28 +39,29 @@ describe('passphrase:encrypt', () => {
 	};
 
 	const printMethodStub = sandbox.stub();
-	const setupStub = test
-		.stub(print, 'default', sandbox.stub().returns(printMethodStub))
-		.stub(config, 'getConfig', sandbox.stub().returns({}))
-		.stub(cryptography, 'getKey', sandbox.stub().returns(defaultKeys))
-		.stub(
-			cryptography,
-			'encryptPassphraseWithPassword',
-			sandbox.stub().returns(encryptedPassphraseObject),
-		)
-		.stub(
-			cryptography,
-			'stringifyEncryptedPassphrase',
-			sandbox.stub().returns(encryptedPassphraseString),
-		)
-		.stub(
-			getInputsFromSources,
-			'default',
-			sandbox.stub().resolves(defaultInputs),
-		);
+	const setupTest = () =>
+		test
+			.stub(print, 'default', sandbox.stub().returns(printMethodStub))
+			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(cryptography, 'getKey', sandbox.stub().returns(defaultKeys))
+			.stub(
+				cryptography,
+				'encryptPassphraseWithPassword',
+				sandbox.stub().returns(encryptedPassphraseObject),
+			)
+			.stub(
+				cryptography,
+				'stringifyEncryptedPassphrase',
+				sandbox.stub().returns(encryptedPassphraseString),
+			)
+			.stub(
+				getInputsFromSources,
+				'default',
+				sandbox.stub().resolves(defaultInputs),
+			);
 
 	describe('passphrase:encrypt', () => {
-		setupStub
+		setupTest()
 			.stdout()
 			.command(['passphrase:encrypt'])
 			.it('should encrypt passphrase', () => {
@@ -90,7 +91,7 @@ describe('passphrase:encrypt', () => {
 	});
 
 	describe('passphrase:encrypt --outputPublicKey', () => {
-		setupStub
+		setupTest()
 			.stdout()
 			.command(['passphrase:encrypt', '--outputPublicKey'])
 			.it('should encrypt passphrase and output public key', () => {
@@ -121,7 +122,7 @@ describe('passphrase:encrypt', () => {
 	});
 
 	describe('passphrase:encrypt --passphrase=pass:123', () => {
-		setupStub
+		setupTest()
 			.stdout()
 			.command(['passphrase:encrypt', '--passphrase=pass:123'])
 			.it('should call print with the user config', () => {
@@ -151,7 +152,7 @@ describe('passphrase:encrypt', () => {
 	});
 
 	describe('passphrase:encrypt --passphrase=pass:123 --password=pass:456', () => {
-		setupStub
+		setupTest()
 			.stdout()
 			.command([
 				'passphrase:encrypt',


### PR DESCRIPTION
### Description
Migration from
```
lisk encrypt passphrase
lisk decrypt passphrase
```

`npm t`
`./bin/run passphrase:encrypt`
`./bin/run passphrase:decrypt`

### Review checklist

* It should be merged after #567
* The PR solves #561  
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
