### PR TITLE
Enable log placeholders - closes #581

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -15,16 +15,7 @@
  */
 import chalk from 'chalk';
 
-// TODO: Include commented placeholders when we support Node 8
-const PLACEHOLDERS = [
-	'%s',
-	'%d',
-	// '%i',
-	// '%f',
-	'%j',
-	// '%o',
-	// '%O',
-];
+const PLACEHOLDERS = ['%s', '%d', '%i', '%f', '%j', '%o', '%O'];
 
 const wrapLogFunction = (fn, colour) => (...args) => {
 	const colourArg = arg => chalk[colour](arg);


### PR DESCRIPTION
### What was the problem?
We would like to use node 8's formatting placeholders. See: https://nodejs.org/docs/latest-v8.x/api/util.html#util_util_format_format_args. But we didn't have node 8 support.
### How did I fix it?
Since we have node 8 support now, I uncommented the new placeholders. 

### Review checklist

* The PR resolves #581 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
