### PR TITLE
Fix block API query key

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -35,7 +35,7 @@ export const PLURALS = {
 
 export const QUERY_INPUT_MAP = {
 	accounts: 'address',
-	blocks: 'id',
+	blocks: 'blockId',
 	delegates: 'username',
 	transactions: 'id',
 };


### PR DESCRIPTION
### What was the problem?
For Block API query key, it was using `id` but it should be `blockId`.

### How did I fix it?
Change the query key to blockId

### How to test it?
```
get block [old block id]
list block [old block id] [old block id]
```

### Review checklist

* The PR solves #590 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
