### PR TITLE
Add filter of args in account:get command

### DIFF
--- a/src/commands/account/get.js
+++ b/src/commands/account/get.js
@@ -41,7 +41,7 @@ GetCommand.args = [
 		name: 'addresses',
 		required: true,
 		description: 'Comma-separated address(es) to get information about.',
-		parse: input => input.split(','),
+		parse: input => input.split(',').filter(Boolean),
 	},
 ];
 

--- a/test/commands/account/get.test.js
+++ b/test/commands/account/get.test.js
@@ -134,10 +134,10 @@ describe('account:get command', () => {
 							{
 								query: {
 									limit: 1,
-									address: addresses[0],
+									address: addressesWithEmpty[0],
 								},
 								placeholder: {
-									address: addresses[0],
+									address: addressesWithEmpty[0],
 									message: 'Address not found.',
 								},
 							},

--- a/test/commands/account/get.test.js
+++ b/test/commands/account/get.test.js
@@ -76,6 +76,7 @@ describe('account:get command', () => {
 
 	describe('account:get addresses', () => {
 		const addresses = ['3520445367460290306L', '2802325248134221536L'];
+		const addressesWithEmpty = ['3520445367460290306L', ''];
 		const queryResult = [
 			{
 				address: addresses[0],
@@ -117,5 +118,33 @@ describe('account:get command', () => {
 				]);
 				return expect(printMethodStub).to.be.calledWithExactly(queryResult);
 			});
+
+		setupTest()
+			.stub(query, 'default', sandbox.stub().resolves(queryResult))
+			.stdout()
+			.command(['account:get', addressesWithEmpty.join(',')])
+			.it(
+				'should get accounts info only using non-empty args and display as an array',
+				() => {
+					expect(api.default).to.be.calledWithExactly(apiConfig);
+					expect(query.default).to.be.calledWithExactly(
+						apiClientStub,
+						endpoint,
+						[
+							{
+								query: {
+									limit: 1,
+									address: addresses[0],
+								},
+								placeholder: {
+									address: addresses[0],
+									message: 'Address not found.',
+								},
+							},
+						],
+					);
+					return expect(printMethodStub).to.be.calledWithExactly(queryResult);
+				},
+			);
 	});
 });


### PR DESCRIPTION
### What was the problem?
When the command had trailing comma, it was causing error from the API

### How did I fix it?
Add filter after splitting the args

### How to test it?
```
lisk account:get 123L,
```

### Review checklist

* The PR solves #592
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
