### PR TITLE
Upgrade lisk-elements to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"bip39": "=2.4.0",
 		"chalk": "=2.3.0",
 		"cli-table3": "=0.5.0",
-		"lisk-elements": "=1.0.0-beta.3",
+		"lisk-elements": "=1.0.0",
 		"lockfile": "=1.0.3",
 		"semver": "=5.5.0",
 		"strip-ansi": "=4.0.0",

--- a/test/specs/utils/api.js
+++ b/test/specs/utils/api.js
@@ -85,7 +85,7 @@ describe('API util', () => {
 						then.theLiskAPIInstanceShouldHaveNethashEqualTo,
 					);
 					Then(
-						'the lisk instance should have nethash equal to "http://testnet.lisk.io:7000"',
+						'the lisk instance should have nethash equal to "https://testnet.lisk.io:443"',
 						then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
 					);
 				},


### PR DESCRIPTION
### What was the problem?
As `lisk-elements` is officially released as `1.0` we should use the version

### Review checklist

* The PR resolves #461 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
