### PR TITLE
Broken link - Closes #599

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The following is a set of guidelines for contributing to Lisk Commander, which a
 
 1. [Code of Conduct](#code-of-conduct)
 
-1. [Help! I don't want to read this whole thing, I just have one question. :mag_right:](#help!-i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
+1. [Help! I don't want to read this whole thing, I just have one question. :mag_right:](#help-i-dont-want-to-read-this-whole-thing-i-just-have-a-question-mag_right)
 
 1. [How Can I Contribute?](#how-can-i-contribute)
 	1. [Reporting Bugs](#reporting-bugs)


### PR DESCRIPTION
Link was not pointing to anywhere. The `mag_right` was missing

### What was the problem?
2nd link of table of contents on docs/ CONTRIBUTING.md was not pointing to anywhere. The `mag_right` was missing
### How did I fix it?
By changing the link
### How to test it?
Click on the link

Closes #599 