### PR TITLE
Use jenkins cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,11 @@ pipeline {
 	stages {
 		stage('Install dependencies') {
 			steps {
-				sh 'npm install --verbose'
+				script {
+					cache_file = restoreCache("package.json")
+					sh 'npm install --verbose'
+					saveCache(cache_file, './node_modules', 10)
+				}
 			}
 		}
 		stage('Run lint') {


### PR DESCRIPTION
### What was the problem?

Missing cache functions for npm. Builds don't take long to install them (few seconds) but better add it for the future.

### How did I fix it?

Adding cache for npm modules

### How to test it?

https://jenkins.lisk.io/job/lisk-commander/job/use_jenkins_cache/5/console

### Review checklist

* The PR resolves #INSERT_ISSUE_NUMBER
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
