### PR TITLE
Fix readme nodejs version - Closes #610

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Lisk Commander allows you to communicate with a remote or local node and carry o
 
 ## Prerequisites
 
-Lisk Commander requires [Node.js](https://nodejs.org/) as the underlying engine for code execution. Node.js is supported on most operating systems. Follow the instructions for your operating system on the [Node.js downloads page](https://nodejs.org/en/download/). You will need version 6.11.x or higher. NPM is automatically installed along with Node.js.
+Lisk Commander requires [Node.js](https://nodejs.org/) as the underlying engine for code execution. Node.js is supported on most operating systems. Follow the instructions for your operating system on the [Node.js downloads page](https://nodejs.org/en/download/). You will need version between 6.12 and 6.14. NPM is automatically installed along with Node.js.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Lisk Commander allows you to communicate with a remote or local node and carry o
 
 ## Prerequisites
 
-Lisk Commander requires [Node.js](https://nodejs.org/) as the underlying engine for code execution. Node.js is supported on most operating systems. Follow the instructions for your operating system on the [Node.js downloads page](https://nodejs.org/en/download/). You will need version between 6.12 and 6.14. NPM is automatically installed along with Node.js.
+Lisk Commander requires [Node.js](https://nodejs.org/) as the underlying engine for code execution. Node.js is supported on most operating systems. Follow the instructions for your operating system on the [Node.js downloads page](https://nodejs.org/en/download/). We currently require Node.js versions between 6.12 and 6.14 (inclusive). NPM is automatically installed along with Node.js.
 
 ## Installation
 


### PR DESCRIPTION
### What was the problem?
Node.js restriction in the Readme was wrong.

### How did I fix it? 
Change to 6.12-6.14

### Review checklist

* The PR resolves #610
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
