### PR TITLE
 Add hook to handle pipe error - Closes #620

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
 	},
 	"oclif": {
 		"commands": "./dist/commands",
+		"hooks": {
+			"init": "./dist/hooks/init/pipe"
+		},
 		"bin": "lisk",
 		"plugins": [
 			"@oclif/plugin-help"

--- a/src/hooks/init/pipe.js
+++ b/src/hooks/init/pipe.js
@@ -1,0 +1,9 @@
+module.exports = async function allowPipe() {
+	function handleEPIPE(err) {
+		if (err.errno !== 'EPIPE') {
+			throw err;
+		}
+	}
+	process.stdout.on('error', handleEPIPE);
+	process.stderr.on('error', handleEPIPE);
+};


### PR DESCRIPTION
### What was the problem?

Node throws EPIPE error if process.stdout is being written to and a user runs it through a pipe that closes prematurely. 

### How did I fix it?

Gracefully handle EPIPE error in oclif init hook.

### Review checklist

* The PR resolves #620 
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)

