### PR TITLE
Add common flag to copyright and warranty - Closes #626

### DIFF
--- a/src/commands/copyright.js
+++ b/src/commands/copyright.js
@@ -38,6 +38,10 @@ export default class CopyrightCommand extends BaseCommand {
 	}
 }
 
+CopyrightCommand.flags = {
+	...BaseCommand.flags,
+};
+
 CopyrightCommand.description = `
 Displays copyright notice.
 `;

--- a/src/commands/warranty.js
+++ b/src/commands/warranty.js
@@ -32,6 +32,10 @@ export default class WarrantyCommand extends BaseCommand {
 	}
 }
 
+WarrantyCommand.flags = {
+	...BaseCommand.flags,
+};
+
 WarrantyCommand.description = `
 Displays warranty notice.
 `;


### PR DESCRIPTION
### What was the problem?
`lisk copyright` and `lisk warranty` was missing common flags.

### How did I fix it?
Add BaseCommand.flag inheritance

### How to test it?
`./bin/run warranty --no-json`
`./bin/run copyright --no-json`

### Review checklist

* The PR resolves #626 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
