### PR TITLE
619-Migrate signature:create command

### DIFF
--- a/docs/account.md
+++ b/docs/account.md
@@ -15,16 +15,19 @@ USAGE
   $ lisk account:create
 
 OPTIONS
-  -j, --[no-]json  Prints output in JSON format. You can change the default behaviour in your config.json file.
+  -j, --[no-]json      Prints output in JSON format. You can change the default behaviour in your config.json file.
 
-  --[no-]pretty    Prints JSON in pretty format rather than condensed. Has no effect if the output is set to table. You
-                   can change the default behaviour in your config.json file.
+  -n, --number=number  [default: 1] Number of accounts to create.
+
+  --[no-]pretty        Prints JSON in pretty format rather than condensed. Has no effect if the output is set to table.
+                       You can change the default behaviour in your config.json file.
 
 DESCRIPTION
   Returns a randomly-generated mnemonic passphrase with its corresponding public/private key pair and Lisk address.
 
-EXAMPLE
+EXAMPLES
   account:create
+  account:create --number=3
 ```
 
 ## `lisk account:get ADDRESSES`

--- a/docs/node.md
+++ b/docs/node.md
@@ -53,11 +53,12 @@ USAGE
   $ lisk node:get
 
 OPTIONS
-  -j, --[no-]json  Prints output in JSON format. You can change the default behaviour in your config.json file.
+  -j, --[no-]json   Prints output in JSON format. You can change the default behaviour in your config.json file.
+
   --forging-status  Additionally provides information about forging status.
 
-  --[no-]pretty    Prints JSON in pretty format rather than condensed. Has no effect if the output is set to table. You
-                   can change the default behaviour in your config.json file.
+  --[no-]pretty     Prints JSON in pretty format rather than condensed. Has no effect if the output is set to table. You
+                    can change the default behaviour in your config.json file.
 
 DESCRIPTION
   Gets information about a node.

--- a/docs/signature.md
+++ b/docs/signature.md
@@ -3,6 +3,7 @@
 Commands relating to signatures for Lisk transactions from multisignature accounts.
 
 * [`lisk signature:broadcast [SIGNATURE]`](#lisk-signature-broadcast-signature)
+* [`lisk signature:create [TRANSACTION]`](#lisk-signature-create-transaction)
 
 ## `lisk signature:broadcast [SIGNATURE]`
 
@@ -29,4 +30,45 @@ DESCRIPTION
 EXAMPLES
   signature:broadcast '{"transactionId":"abcd1234","publicKey":"abcd1234","signature":"abcd1234"}'
   echo '{"transactionId":"abcd1234","publicKey":"abcd1234","signature":"abcd1234"}' | lisk signature:broadcast
+```
+
+## `lisk signature:create [TRANSACTION]`
+
+Create a signature object for a transaction from a multisignature account.
+
+```
+USAGE
+  $ lisk signature:create [TRANSACTION]
+
+ARGUMENTS
+  TRANSACTION  Transaction in JSON format.
+
+OPTIONS
+  -j, --[no-]json
+      Prints output in JSON format. You can change the default behaviour in your config.json file.
+
+  -p, --passphrase=passphrase
+      Specifies a source for your secret passphrase. Lisk Commander will prompt you for input if this option is not set.
+      	Source must be one of `prompt`, `pass`, `env`, `file` or `stdin`. For `pass`, `env` and `file` a corresponding
+      identifier must also be provided.
+      	Examples:
+      	- --passphrase=prompt (default behaviour)
+      	- --passphrase='pass:my secret passphrase' (should only be used where security is not important)
+      	- --passphrase=env:SECRET_PASSPHRASE
+      	- --passphrase=file:/path/to/my/passphrase.txt (takes the first line only)
+      	- --passphrase=stdin (takes one line only)
+
+  --[no-]pretty
+      Prints JSON in pretty format rather than condensed. Has no effect if the output is set to table. You can change the
+      default behaviour in your config.json file.
+
+DESCRIPTION
+  Create a signature object for a transaction from a multisignature account.
+  Accepts a stringified JSON transaction as an argument.
+
+EXAMPLE
+  signature:create
+  '{"amount":"10","recipientId":"8050281191221330746L","senderPublicKey":"3358a1562f9babd523a768e700bb12ad58f230f8403105
+  5802dc0ea58cef1e1b","timestamp":59353522,"type":0,"asset":{},"signature":"b84b95087c381ad25b5701096e2d9366ffd04037dcc9
+  41cd0747bfb0cf93111834a6c662f149018be4587e6fc4c9f5ba47aa5bbbd3dd836988f153aa8258e604"}'
 ```

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -5,7 +5,7 @@ Commands relating to Lisk transactions.
 * [`lisk transaction:broadcast [TRANSACTION]`](#lisk-transaction-broadcast-transaction)
 * [`lisk transaction:create`](#lisk-transaction-create)
 * [`lisk transaction:create:transfer AMOUNT ADDRESS`](#lisk-transaction-create-transfer-amount-address)
-* [`lisk transaction:create:second-passphrase`](#lisk-transaction-createsecond-passphrase)
+* [`lisk transaction:create:second-passphrase`](#lisk-transaction-create-second-passphrase)
 * [`lisk transaction:create:delegate USERNAME`](#lisk-transaction-create-delegate-username)
 * [`lisk transaction:create:vote`](#lisk-transaction-create-vote)
 * [`lisk transaction:create:multisignature LIFETIME MINIMUM KEYSGROUP`](#lisk-transaction-create-multisignature-lifetime-minimum-keysgroup)

--- a/src/commands/signature/create.js
+++ b/src/commands/signature/create.js
@@ -1,0 +1,84 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2017–2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import elements from 'lisk-elements';
+import { flags as flagParser } from '@oclif/command';
+import BaseCommand from '../../base';
+import { getRawStdIn } from '../../utils/input/utils';
+import { ValidationError } from '../../utils/error';
+import parseTransactionString from '../../utils/transactions';
+import getInputsFromSources from '../../utils/input';
+import commonFlags from '../../utils/flags';
+
+const getTransactionInput = async () =>
+	getRawStdIn()
+		.then(rawStdIn => {
+			if (rawStdIn.length <= 0) {
+				throw new ValidationError('No transaction was provided.');
+			}
+			return rawStdIn[0];
+		})
+		.catch(() => {
+			throw new ValidationError('No transaction was provided.');
+		});
+
+export default class CreateCommand extends BaseCommand {
+	async run() {
+		const {
+			args: { transaction },
+			flags: { passphrase: passphraseSource },
+		} = this.parse(CreateCommand);
+
+		const transactionInput =
+			transaction || (await getTransactionInput(transaction));
+
+		const transactionObject = parseTransactionString(transactionInput);
+
+		const { passphrase } = await getInputsFromSources({
+			passphrase: {
+				source: passphraseSource,
+				repeatPrompt: true,
+			},
+		});
+
+		const result = elements.transaction.createSignatureObject(
+			transactionObject,
+			passphrase,
+		);
+
+		this.print(result);
+	}
+}
+
+CreateCommand.args = [
+	{
+		name: 'transaction',
+		description: 'Transaction in JSON format.',
+	},
+];
+
+CreateCommand.flags = {
+	...BaseCommand.flags,
+	passphrase: flagParser.string(commonFlags.passphrase),
+};
+
+CreateCommand.description = `
+Create a signature object for a transaction from a multisignature account.
+Accepts a stringified JSON transaction as an argument.
+`;
+
+CreateCommand.examples = [
+	'signature:create \'{"type":0,"amount":"10","recipientId":"100L","senderPublicKey":"abcd1234","timestamp":59353522,"asset":{},"id":"abcd1234","signature":"abcd1234"}\'',
+];

--- a/src/commands/signature/create.js
+++ b/src/commands/signature/create.js
@@ -80,5 +80,5 @@ Accepts a stringified JSON transaction as an argument.
 `;
 
 CreateCommand.examples = [
-	'signature:create \'{"type":0,"amount":"10","recipientId":"100L","senderPublicKey":"abcd1234","timestamp":59353522,"asset":{},"id":"abcd1234","signature":"abcd1234"}\'',
+	'signature:create \'{"amount":"10","recipientId":"8050281191221330746L","senderPublicKey":"3358a1562f9babd523a768e700bb12ad58f230f84031055802dc0ea58cef1e1b","timestamp":59353522,"type":0,"asset":{},"signature":"b84b95087c381ad25b5701096e2d9366ffd04037dcc941cd0747bfb0cf93111834a6c662f149018be4587e6fc4c9f5ba47aa5bbbd3dd836988f153aa8258e604"}\'',
 ];

--- a/test/commands/signature/create.test.js
+++ b/test/commands/signature/create.test.js
@@ -1,0 +1,217 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2017–2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { test } from '@oclif/test';
+import * as elements from 'lisk-elements';
+import * as config from '../../../src/utils/config';
+import * as print from '../../../src/utils/print';
+import * as inputUtils from '../../../src/utils/input/utils';
+import * as getInputsFromSources from '../../../src/utils/input';
+
+describe('signature:create', () => {
+	const defaultTransaction = {
+		amount: '10',
+		recipientId: '8050281191221330746L',
+		senderPublicKey:
+			'3358a1562f9babd523a768e700bb12ad58f230f84031055802dc0ea58cef1e1b',
+		timestamp: 59353522,
+		type: 0,
+		fee: '10000000',
+		recipientPublicKey: null,
+		asset: {},
+		signature:
+			'b84b95087c381ad25b5701096e2d9366ffd04037dcc941cd0747bfb0cf93111834a6c662f149018be4587e6fc4c9f5ba47aa5bbbd3dd836988f153aa8258e604',
+		id: '3694188453012384790',
+	};
+	const invalidTransaction = 'invalid transaction';
+	const defaultInputs = {
+		passphrase: '123',
+	};
+
+	const defaultSignatureObject = {
+		transactionId: '3694188453012384790',
+		publicKey:
+			'6edfa4a73d7e2a71e61fbb80aaf6e578a9c7be779382c6d7fc99e086400c830f',
+		signature:
+			'ba8250a2192cb0b70283993d4fa6c6e625a422b16829b38a6c6c14b2ad82411e2e8523abac35162e1c28d8dd35bbe7821b2945640c8baab95b00fb2525bdb807',
+	};
+
+	const transactionStub = sandbox.stub().returns(defaultSignatureObject);
+
+	const printMethodStub = sandbox.stub();
+	const setupTest = () =>
+		test
+			.stub(print, 'default', sandbox.stub().returns(printMethodStub))
+			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				elements.default.transaction,
+				'createSignatureObject',
+				transactionStub,
+			)
+			.stub(
+				getInputsFromSources,
+				'default',
+				sandbox.stub().resolves(defaultInputs),
+			)
+			.stdout();
+
+	describe('signature:create', () => {
+		setupTest()
+			.stub(
+				inputUtils,
+				'getRawStdIn',
+				sandbox.stub().rejects(new Error('Timeout error')),
+			)
+			.command(['signature:create'])
+			.catch(error => {
+				return expect(error.message).to.contain('No transaction was provided.');
+			})
+			.it('should throw an error');
+	});
+
+	describe('signature:create transaction', () => {
+		setupTest()
+			.command(['signature:create', invalidTransaction])
+			.catch(error => {
+				return expect(error.message).to.contain(
+					'Could not parse transaction JSON.',
+				);
+			})
+			.it('should throw an error');
+
+		setupTest()
+			.command(['signature:create', JSON.stringify(defaultTransaction)])
+			.it('should take transaction from arg to create', () => {
+				expect(getInputsFromSources.default).to.be.calledWithExactly({
+					passphrase: {
+						source: undefined,
+						repeatPrompt: true,
+					},
+				});
+				expect(transactionStub).to.be.calledWithExactly(
+					defaultTransaction,
+					defaultInputs.passphrase,
+				);
+				return expect(printMethodStub).to.be.calledWithExactly(
+					defaultSignatureObject,
+				);
+			});
+	});
+
+	describe('signature:create --passphrase=pass:xxx', () => {
+		setupTest()
+			.command([
+				'signature:create',
+				JSON.stringify(defaultTransaction),
+				'--passphrase=pass:123',
+			])
+			.it(
+				'should take transaction from arg and passphrase from flag to create',
+				() => {
+					expect(getInputsFromSources.default).to.be.calledWithExactly({
+						passphrase: {
+							source: 'pass:123',
+							repeatPrompt: true,
+						},
+					});
+					expect(transactionStub).to.be.calledWithExactly(
+						defaultTransaction,
+						defaultInputs.passphrase,
+					);
+					return expect(printMethodStub).to.be.calledWithExactly(
+						defaultSignatureObject,
+					);
+				},
+			);
+	});
+
+	describe('transaction | signature:create', () => {
+		setupTest()
+			.stub(inputUtils, 'getRawStdIn', sandbox.stub().resolves([]))
+			.command(['signature:create'])
+			.catch(error => {
+				return expect(error.message).to.contain('No transaction was provided.');
+			})
+			.it('should throw an error when stdin is empty');
+
+		setupTest()
+			.stub(
+				inputUtils,
+				'getRawStdIn',
+				sandbox.stub().resolves([invalidTransaction]),
+			)
+			.command(['signature:create'])
+			.catch(error => {
+				return expect(error.message).to.contain(
+					'Could not parse transaction JSON.',
+				);
+			})
+			.it('should throw an error when std is an invalid JSON format');
+
+		setupTest()
+			.stub(
+				inputUtils,
+				'getRawStdIn',
+				sandbox.stub().resolves([JSON.stringify(defaultTransaction)]),
+			)
+			.command(['signature:create'])
+			.it(
+				'should take transaction from stdin and create signature object',
+				() => {
+					expect(getInputsFromSources.default).to.be.calledWithExactly({
+						passphrase: {
+							source: undefined,
+							repeatPrompt: true,
+						},
+					});
+					expect(transactionStub).to.be.calledWithExactly(
+						defaultTransaction,
+						defaultInputs.passphrase,
+					);
+					return expect(printMethodStub).to.be.calledWithExactly(
+						defaultSignatureObject,
+					);
+				},
+			);
+	});
+
+	describe('transaction | signature:create --passphrase=pass:xxx', () => {
+		setupTest()
+			.stub(
+				inputUtils,
+				'getRawStdIn',
+				sandbox.stub().resolves([JSON.stringify(defaultTransaction)]),
+			)
+			.command(['signature:create', '--passphrase=pass:123'])
+			.it(
+				'should take transaction from stdin and sign with passphrase from flag',
+				() => {
+					expect(getInputsFromSources.default).to.be.calledWithExactly({
+						passphrase: {
+							source: 'pass:123',
+							repeatPrompt: true,
+						},
+					});
+					expect(transactionStub).to.be.calledWithExactly(
+						defaultTransaction,
+						defaultInputs.passphrase,
+					);
+					return expect(printMethodStub).to.be.calledWithExactly(
+						defaultSignatureObject,
+					);
+				},
+			);
+	});
+});

--- a/test/commands/signature/create.test.js
+++ b/test/commands/signature/create.test.js
@@ -48,8 +48,6 @@ describe('signature:create', () => {
 			'ba8250a2192cb0b70283993d4fa6c6e625a422b16829b38a6c6c14b2ad82411e2e8523abac35162e1c28d8dd35bbe7821b2945640c8baab95b00fb2525bdb807',
 	};
 
-	const transactionStub = sandbox.stub().returns(defaultSignatureObject);
-
 	const printMethodStub = sandbox.stub();
 	const setupTest = () =>
 		test
@@ -58,7 +56,7 @@ describe('signature:create', () => {
 			.stub(
 				elements.default.transaction,
 				'createSignatureObject',
-				transactionStub,
+				sandbox.stub().returns(defaultSignatureObject),
 			)
 			.stub(
 				getInputsFromSources,
@@ -100,10 +98,9 @@ describe('signature:create', () => {
 						repeatPrompt: true,
 					},
 				});
-				expect(transactionStub).to.be.calledWithExactly(
-					defaultTransaction,
-					defaultInputs.passphrase,
-				);
+				expect(
+					elements.default.transaction.createSignatureObject,
+				).to.be.calledWithExactly(defaultTransaction, defaultInputs.passphrase);
 				return expect(printMethodStub).to.be.calledWithExactly(
 					defaultSignatureObject,
 				);
@@ -126,7 +123,9 @@ describe('signature:create', () => {
 							repeatPrompt: true,
 						},
 					});
-					expect(transactionStub).to.be.calledWithExactly(
+					expect(
+						elements.default.transaction.createSignatureObject,
+					).to.be.calledWithExactly(
 						defaultTransaction,
 						defaultInputs.passphrase,
 					);
@@ -176,7 +175,9 @@ describe('signature:create', () => {
 							repeatPrompt: true,
 						},
 					});
-					expect(transactionStub).to.be.calledWithExactly(
+					expect(
+						elements.default.transaction.createSignatureObject,
+					).to.be.calledWithExactly(
 						defaultTransaction,
 						defaultInputs.passphrase,
 					);
@@ -204,7 +205,9 @@ describe('signature:create', () => {
 							repeatPrompt: true,
 						},
 					});
-					expect(transactionStub).to.be.calledWithExactly(
+					expect(
+						elements.default.transaction.createSignatureObject,
+					).to.be.calledWithExactly(
 						defaultTransaction,
 						defaultInputs.passphrase,
 					);


### PR DESCRIPTION
### What was the problem?

Commander 2.0 doesn't have a way to signature for multi-signature transaction.

### How did I fix it?

Create `signature:create` command

### How to test it?

Build, lint, test.

### Review checklist

* The PR resolves #619
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
