### PR TITLE
Fix npm publish result - Cloese #630

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"prebuild": "if test -d dist; then rm -r dist; fi",
 		"build": "babel src -d dist",
 		"postpack": "rm -f oclif.manifest.json",
-		"prepack": "oclif-dev manifest && oclif-dev readme && npm shrinkwrap",
+		"prepack": "oclif-dev manifest && npm shrinkwrap",
 		"precommit": "lint-staged && npm run lint",
 		"prepush": "npm run lint && npm test",
 		"prepublishOnly": "rm -r ./node_modules && npm install && npm run prepush && npm run build"
@@ -99,7 +99,9 @@
 		"/bin",
 		"/npm-shrinkwrap.json",
 		"/oclif.manifest.json",
-		"/dist"
+		"/dist",
+		"/docs",
+		"/default_config.json"
 	],
 	"dependencies": {
 		"@oclif/command": "1.5.0",


### PR DESCRIPTION
### What was the problem?
Published NPM did not have required file, and it was overwriting the README.md

### How did I fix it?
In `package.json`, `docs`, `default_config.json` are included in the `files` and stop generating README on publish

### How to test it?

### Review checklist

* The PR resolves #630 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
