### PR TITLE
Add data field option to type 0 transaction creator - Closes#606

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -122,7 +122,7 @@ ARGUMENTS
 
 OPTIONS
   -d, --data=data
-      Specifies the data for the transaction type 0. Takes a string.
+      Message of UTF-8 string to attach, which has a maximum length of 64 bytes.
       	Examples:
       	- --data=customInformation
 

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -122,7 +122,7 @@ ARGUMENTS
 
 OPTIONS
   -d, --data=data
-      Message of UTF-8 string to attach, which has a maximum length of 64 bytes.
+      Optional UTF8 encoded data (maximum of 64 bytes) to include in the transaction asset.
       	Examples:
       	- --data=customInformation
 

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -121,6 +121,11 @@ ARGUMENTS
   ADDRESS  Address of the recipient.
 
 OPTIONS
+  -d, --data=data
+      Specifies the data for the transaction type 0. Takes a string.
+      	Examples:
+      	- --data=customInformation
+
   -j, --[no-]json
       Prints output in JSON format. You can change the default behaviour in your config.json file.
 

--- a/src/commands/transaction/create/transfer.js
+++ b/src/commands/transaction/create/transfer.js
@@ -21,7 +21,7 @@ import getInputsFromSources from '../../../utils/input';
 
 const dataFlag = {
 	char: 'd',
-	description: `Message of UTF-8 string to attach, which has a maximum length of 64 bytes.
+	description: `Optional UTF8 encoded data (maximum of 64 bytes) to include in the transaction asset.
 	Examples:
 	- --data=customInformation
 `,

--- a/src/commands/transaction/create/transfer.js
+++ b/src/commands/transaction/create/transfer.js
@@ -19,6 +19,14 @@ import BaseCommand from '../../../base';
 import commonFlags from '../../../utils/flags';
 import getInputsFromSources from '../../../utils/input';
 
+const dataFlag = {
+	char: 'd',
+	description: `Specifies the data for the transaction type 0. Takes a string.
+	Examples:
+	- --data=customInformation
+`,
+};
+
 const processInputs = (amount, address, data) => ({
 	passphrase,
 	secondPassphrase,
@@ -97,7 +105,7 @@ TransferCommand.flags = {
 	passphrase: flagParser.string(commonFlags.passphrase),
 	'second-passphrase': flagParser.string(commonFlags.secondPassphrase),
 	'no-signature': flagParser.boolean(commonFlags.noSignature),
-	data: flagParser.string(commonFlags.data),
+	data: flagParser.string(dataFlag),
 };
 
 TransferCommand.description = `

--- a/src/commands/transaction/create/transfer.js
+++ b/src/commands/transaction/create/transfer.js
@@ -43,17 +43,6 @@ export default class TransferCommand extends BaseCommand {
 			},
 		} = this.parse(TransferCommand);
 
-		if (dataString && dataString.length > 0) {
-			if (dataString.length > elements.transaction.constants.BYTESIZES.DATA) {
-				throw new Error('Transaction data field cannot exceed 64 bytes.');
-			}
-			if (dataString !== dataString.toString('utf8')) {
-				throw new Error(
-					'Invalid encoding in transaction data. Data must be utf-8 encoded.',
-				);
-			}
-		}
-
 		elements.transaction.utils.validateAddress(address);
 		const normalizedAmount = elements.transaction.utils.convertLSKToBeddows(
 			amount,

--- a/src/commands/transaction/create/transfer.js
+++ b/src/commands/transaction/create/transfer.js
@@ -21,7 +21,7 @@ import getInputsFromSources from '../../../utils/input';
 
 const dataFlag = {
 	char: 'd',
-	description: `Specifies the data for the transaction type 0. Takes a string.
+	description: `Message of UTF-8 string to attach, which has a maximum length of 64 bytes.
 	Examples:
 	- --data=customInformation
 `,

--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -13,12 +13,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const dataDescription = `Specifies a source for providing a transaction data to the command. If a string is provided directly as an argument, this option will be ignored. The data must be provided via an argument or via this option. Sources must be one of \`file\` or \`stdin\`. In the case of \`file\`, a corresponding identifier must also be provided.
-	Examples:
-	- --data=file:/path/to/my/data.txt
-	- --data=stdin
-`;
-
 const messageDescription = `Specifies a source for providing a message to the command. If a string is provided directly as an argument, this option will be ignored. The message must be provided via an argument or via this option. Sources must be one of \`file\` or \`stdin\`. In the case of \`file\`, a corresponding identifier must also be provided.
 	Note: if both secret passphrase and message are passed via stdin, the passphrase must be the first line.
 	Examples:
@@ -72,10 +66,6 @@ const noSignatureDescription =
 	'Creates the transaction without a signature. Your passphrase will therefore not be required.';
 
 const flags = {
-	data: {
-		char: 'd',
-		description: dataDescription,
-	},
 	message: {
 		char: 'm',
 		description: messageDescription,

--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -13,6 +13,12 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+const dataDescription = `Specifies a source for providing a transaction data to the command. If a string is provided directly as an argument, this option will be ignored. The data must be provided via an argument or via this option. Sources must be one of \`file\` or \`stdin\`. In the case of \`file\`, a corresponding identifier must also be provided.
+	Examples:
+	- --data=file:/path/to/my/data.txt
+	- --data=stdin
+`;
+
 const messageDescription = `Specifies a source for providing a message to the command. If a string is provided directly as an argument, this option will be ignored. The message must be provided via an argument or via this option. Sources must be one of \`file\` or \`stdin\`. In the case of \`file\`, a corresponding identifier must also be provided.
 	Note: if both secret passphrase and message are passed via stdin, the passphrase must be the first line.
 	Examples:
@@ -66,6 +72,10 @@ const noSignatureDescription =
 	'Creates the transaction without a signature. Your passphrase will therefore not be required.';
 
 const flags = {
+	data: {
+		char: 'd',
+		description: dataDescription,
+	},
 	message: {
 		char: 'm',
 		description: messageDescription,

--- a/test/commands/transaction/create/transfer.test.js
+++ b/test/commands/transaction/create/transfer.test.js
@@ -101,6 +101,34 @@ describe('transaction:create:transfer', () => {
 			});
 	});
 
+	describe('transaction:create:transfer amount address --data=xxx', () => {
+		setupTest()
+			.command([
+				'transaction:create:transfer',
+				defaultAmount,
+				defaultAddress,
+				'--data=XXXXXX',
+			])
+			.it('should create an tranfer transaction', () => {
+				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
+					defaultAddress,
+				);
+				expect(transactionUtilStub.convertLSKToBeddows).to.be.calledWithExactly(
+					defaultAmount,
+				);
+				expect(getInputsFromSources.default).to.be.calledWithExactly({
+					passphrase: {
+						source: undefined,
+						repeatPrompt: true,
+					},
+					secondPassphrase: null,
+				});
+				return expect(printMethodStub).to.be.calledWithExactly(
+					defaultTransaction,
+				);
+			});
+	});
+
 	describe('transaction:create:transfer amount address --no-signature', () => {
 		setupTest()
 			.command([

--- a/test/commands/transaction/create/transfer.test.js
+++ b/test/commands/transaction/create/transfer.test.js
@@ -81,7 +81,7 @@ describe('transaction:create:transfer', () => {
 	describe('transaction:create:transfer amount address', () => {
 		setupTest()
 			.command(['transaction:create:transfer', defaultAmount, defaultAddress])
-			.it('should create an tranfer transaction', () => {
+			.it('should create a tranfer transaction', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);
@@ -109,7 +109,7 @@ describe('transaction:create:transfer', () => {
 				defaultAddress,
 				'--data=Testing lisk transaction data.',
 			])
-			.it('should create an tranfer transaction', () => {
+			.it('should create a tranfer transaction', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);
@@ -137,7 +137,7 @@ describe('transaction:create:transfer', () => {
 				defaultAddress,
 				'--no-signature',
 			])
-			.it('should create an tranfer transaction without signature', () => {
+			.it('should create a tranfer transaction without signature', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);
@@ -159,7 +159,7 @@ describe('transaction:create:transfer', () => {
 				defaultAddress,
 				'--passphrase=pass:123',
 			])
-			.it('should create an tranfer transaction', () => {
+			.it('should create a tranfer transaction', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);
@@ -188,7 +188,7 @@ describe('transaction:create:transfer', () => {
 				'--passphrase=pass:123',
 				'--second-passphrase=pass:456',
 			])
-			.it('should create an tranfer transaction', () => {
+			.it('should create a tranfer transaction', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);

--- a/test/commands/transaction/create/transfer.test.js
+++ b/test/commands/transaction/create/transfer.test.js
@@ -81,7 +81,7 @@ describe('transaction:create:transfer', () => {
 	describe('transaction:create:transfer amount address', () => {
 		setupTest()
 			.command(['transaction:create:transfer', defaultAmount, defaultAddress])
-			.it('should create a tranfer transaction', () => {
+			.it('should create a transfer transaction', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);
@@ -109,7 +109,7 @@ describe('transaction:create:transfer', () => {
 				defaultAddress,
 				'--data=Testing lisk transaction data.',
 			])
-			.it('should create a tranfer transaction', () => {
+			.it('should create a transfer transaction', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);
@@ -137,7 +137,7 @@ describe('transaction:create:transfer', () => {
 				defaultAddress,
 				'--no-signature',
 			])
-			.it('should create a tranfer transaction without signature', () => {
+			.it('should create a transfer transaction without signature', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);
@@ -159,7 +159,7 @@ describe('transaction:create:transfer', () => {
 				defaultAddress,
 				'--passphrase=pass:123',
 			])
-			.it('should create a tranfer transaction', () => {
+			.it('should create a transfer transaction', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);
@@ -188,7 +188,7 @@ describe('transaction:create:transfer', () => {
 				'--passphrase=pass:123',
 				'--second-passphrase=pass:456',
 			])
-			.it('should create a tranfer transaction', () => {
+			.it('should create a transfer transaction', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(
 					defaultAddress,
 				);

--- a/test/commands/transaction/create/transfer.test.js
+++ b/test/commands/transaction/create/transfer.test.js
@@ -107,7 +107,7 @@ describe('transaction:create:transfer', () => {
 				'transaction:create:transfer',
 				defaultAmount,
 				defaultAddress,
-				'--data=XXXXXX',
+				'--data=Testing lisk transaction data.',
 			])
 			.it('should create an tranfer transaction', () => {
 				expect(transactionUtilStub.validateAddress).to.be.calledWithExactly(


### PR DESCRIPTION
### **Description**

There was no flag to take data field for `0` type transaction when creating one. Now it has been added as an option using `-d` flag. 

* The PR resolves #606 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
