### PR TITLE
Validate transaction before sign - Closes #629

### DIFF
--- a/src/commands/signature/create.js
+++ b/src/commands/signature/create.js
@@ -45,6 +45,11 @@ export default class CreateCommand extends BaseCommand {
 
 		const transactionObject = parseTransactionString(transactionInput);
 
+		const { valid } = transactions.utils.validateTransaction(transactionObject);
+		if (!valid) {
+			throw new Error('Provided transaction is invalid.');
+		}
+
 		const { passphrase } = await getInputsFromSources({
 			passphrase: {
 				source: passphraseSource,

--- a/test/commands/signature/create.test.js
+++ b/test/commands/signature/create.test.js
@@ -58,6 +58,9 @@ describe('signature:create', () => {
 				'createSignatureObject',
 				sandbox.stub().returns(defaultSignatureObject),
 			)
+			.stub(transactions, 'utils', {
+				validateTransaction: sandbox.stub().returns({ valid: true }),
+			})
 			.stub(
 				getInputsFromSources,
 				'default',
@@ -88,6 +91,18 @@ describe('signature:create', () => {
 				);
 			})
 			.it('should throw an error');
+
+		setupTest()
+			.stub(transactions, 'utils', {
+				validateTransaction: sandbox.stub().returns({ valid: false }),
+			})
+			.command(['signature:create', JSON.stringify(defaultTransaction)])
+			.catch(error => {
+				return expect(error.message).to.contain(
+					'Provided transaction is invalid.',
+				);
+			})
+			.it('should throw an error when transaction is invalid');
 
 		setupTest()
 			.command(['signature:create', JSON.stringify(defaultTransaction)])


### PR DESCRIPTION
### What was the problem?
Currently it's possible to sign invalid transactions, but user should not be able to sign an invalid transaction.

### Review checklist

* The PR resolves #629 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
