### PR TITLE
Add validation before signing for transaction - Closes #532

### DIFF
--- a/src/commands/transaction/sign.js
+++ b/src/commands/transaction/sign.js
@@ -47,6 +47,11 @@ export default class SignCommand extends BaseCommand {
 		const transactionInput = transaction || (await getTransactionInput());
 		const transactionObject = parseTransactionString(transactionInput);
 
+		const { valid } = transactions.utils.validateTransaction(transactionObject);
+		if (!valid) {
+			throw new Error('Provided transaction is invalid.');
+		}
+
 		const { passphrase, secondPassphrase } = await getInputsFromSources({
 			passphrase: {
 				source: passphraseSource,

--- a/test/commands/transaction/sign.test.js
+++ b/test/commands/transaction/sign.test.js
@@ -44,6 +44,7 @@ describe('transaction:sign', () => {
 
 	const transactionUtilStub = {
 		prepareTransaction: sandbox.stub().returns(defaultSignedTransaction),
+		validateTransaction: sandbox.stub().returns({ valid: true }),
 	};
 
 	const printMethodStub = sandbox.stub();
@@ -82,6 +83,18 @@ describe('transaction:sign', () => {
 				);
 			})
 			.it('should throw an error');
+
+		setupTest()
+			.stub(transactions, 'utils', {
+				validateTransaction: sandbox.stub().returns({ valid: false }),
+			})
+			.command(['transaction:sign', JSON.stringify(defaultTransaction)])
+			.catch(error => {
+				return expect(error.message).to.contain(
+					'Provided transaction is invalid.',
+				);
+			})
+			.it('should throw an error when transaction is invalid');
 
 		setupTest()
 			.command(['transaction:sign', JSON.stringify(defaultTransaction)])


### PR DESCRIPTION
### What was the problem?
When signing the transaction, user was able to sign invalid transaction.
However, invalid transaction should not be tried to sign.

### How did I fix it?

### How to test it?
```
./bin/run transaction:sign '{ type: 0 }'
```

### Review checklist

* The PR resolves #532 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
