### PR TITLE
Display warning for passphrase format - Closes #337

### DIFF
--- a/src/utils/input/index.js
+++ b/src/utils/input/index.js
@@ -13,7 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import * as elements from 'lisk-elements';
+import { passphrase as passphraseModule } from 'lisk-elements';
 import { getStdIn, getPassphrase, getData } from './utils';
 
 export const getFirstLineFromString = multilineString =>
@@ -61,7 +61,7 @@ const getInputsFromSources = async ({
 	const passphraseErrors = [passphrase, secondPassphrase].reduce(
 		(accumulator, input) => {
 			if (input) {
-				const errors = elements.passphrase.validation
+				const errors = passphraseModule.validation
 					.getPassphraseValidationErrors(input)
 					.filter(error => error.message);
 				if (accumulator.length === 0) {
@@ -78,9 +78,15 @@ const getInputsFromSources = async ({
 		const uniquePassphraseErrors = [...new Set(passphraseErrors)].filter(
 			error => error.code !== 'INVALID_MNEMONIC',
 		);
-		uniquePassphraseErrors.forEach(error =>
-			console.info(`Warning: ${error.message}`),
+
+		const passphraseWarning = uniquePassphraseErrors.reduce(
+			(accumulator, error) =>
+				accumulator.concat(
+					`${error.message.replace(' Please check the passphrase.', '')} `,
+				),
+			'Warning: ',
 		);
+		console.warn(passphraseWarning);
 	}
 
 	const password =

--- a/src/utils/input/index.js
+++ b/src/utils/input/index.js
@@ -58,36 +58,28 @@ const getInputsFromSources = async ({
 				})
 			: stdIn.secondPassphrase || null;
 
-	const passphraseErrors = [passphrase, secondPassphrase].reduce(
-		(accumulator, input) => {
-			if (input) {
-				const errors = passphraseModule.validation
-					.getPassphraseValidationErrors(input)
-					.filter(error => error.message);
-				if (accumulator.length === 0) {
-					return errors;
-				}
-				return [...accumulator, ...errors];
-			}
-			return accumulator;
-		},
-		[],
-	);
-
-	if (passphraseErrors.length > 0) {
-		const uniquePassphraseErrors = [...new Set(passphraseErrors)].filter(
-			error => error.code !== 'INVALID_MNEMONIC',
+	const passphraseErrors = [passphrase, secondPassphrase]
+		.filter(Boolean)
+		.map(pass =>
+			passphraseModule.validation
+				.getPassphraseValidationErrors(pass)
+				.filter(error => error.message),
 		);
 
-		const passphraseWarning = uniquePassphraseErrors.reduce(
-			(accumulator, error) =>
-				accumulator.concat(
-					`${error.message.replace(' Please check the passphrase.', '')} `,
-				),
-			'Warning: ',
-		);
-		console.warn(passphraseWarning);
-	}
+	passphraseErrors.forEach(errors => {
+		if (errors.length > 0) {
+			const passphraseWarning = errors
+				.filter(error => error.code !== 'INVALID_MNEMONIC')
+				.reduce(
+					(accumulator, error) =>
+						accumulator.concat(
+							`${error.message.replace(' Please check the passphrase.', '')} `,
+						),
+					'Warning: ',
+				);
+			console.warn(passphraseWarning);
+		}
+	});
 
 	const password =
 		typeof stdIn.password !== 'string' && passwordInput

--- a/src/utils/input/index.js
+++ b/src/utils/input/index.js
@@ -13,6 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import * as elements from 'lisk-elements';
 import { getStdIn, getPassphrase, getData } from './utils';
 
 export const getFirstLineFromString = multilineString =>
@@ -56,6 +57,31 @@ const getInputsFromSources = async ({
 					shouldRepeat: secondPassphraseInput.repeatPrompt,
 				})
 			: stdIn.secondPassphrase || null;
+
+	const passphraseErrors = [passphrase, secondPassphrase].reduce(
+		(accumulator, input) => {
+			if (input) {
+				const errors = elements.passphrase.validation
+					.getPassphraseValidationErrors(input)
+					.filter(error => error.message);
+				if (accumulator.length === 0) {
+					return errors;
+				}
+				return [...accumulator, ...errors];
+			}
+			return accumulator;
+		},
+		[],
+	);
+
+	if (passphraseErrors.length > 0) {
+		const uniquePassphraseErrors = [...new Set(passphraseErrors)].filter(
+			error => error.code !== 'INVALID_MNEMONIC',
+		);
+		uniquePassphraseErrors.forEach(error =>
+			console.info(`Warning: ${error.message}`),
+		);
+	}
 
 	const password =
 		typeof stdIn.password !== 'string' && passwordInput

--- a/test/utils/input/index.js
+++ b/test/utils/input/index.js
@@ -88,11 +88,9 @@ describe('input utils', () => {
 					passphrase: stdin,
 				});
 				await getInputsFromSources(inputs);
-				expect(
-					console.warn.calledWith(
-						'Warning: Passphrase contains 2 words instead of expected 12. ',
-					),
-				).to.be.true;
+				return expect(console.warn).to.be.calledWithExactly(
+					'Warning: Passphrase contains 2 words instead of expected 12. ',
+				);
 			});
 		});
 
@@ -137,11 +135,9 @@ describe('input utils', () => {
 					secondPassphrase: stdin,
 				});
 				await getInputsFromSources(inputs);
-				expect(
-					console.warn.calledWith(
-						'Warning: Passphrase contains 2 words instead of expected 12. ',
-					),
-				).to.be.true;
+				return expect(console.warn).to.be.calledWithExactly(
+					'Warning: Passphrase contains 2 words instead of expected 12. ',
+				);
 			});
 		});
 

--- a/test/utils/input/index.js
+++ b/test/utils/input/index.js
@@ -88,9 +88,11 @@ describe('input utils', () => {
 					passphrase: stdin,
 				});
 				await getInputsFromSources(inputs);
-				expect(console.warn.getCall(0).args[0].trim()).to.equal(
-					'Warning: Passphrase contains 2 words instead of expected 12.',
-				);
+				expect(
+					console.warn.calledWith(
+						'Warning: Passphrase contains 2 words instead of expected 12. ',
+					),
+				).to.be.true;
 			});
 		});
 
@@ -129,15 +131,17 @@ describe('input utils', () => {
 				return expect(result.secondPassphrase).to.be.null;
 			});
 
-			it('should print a warning if passphase not in mnemonic format', async () => {
+			it('should print a warning if secondPassphase not in mnemonic format', async () => {
 				const stdin = 'some passphrase';
 				inputUtils.getStdIn.resolves({
 					secondPassphrase: stdin,
 				});
 				await getInputsFromSources(inputs);
-				expect(console.warn.getCall(0).args[0].trim()).to.equal(
-					'Warning: Passphrase contains 2 words instead of expected 12.',
-				);
+				expect(
+					console.warn.calledWith(
+						'Warning: Passphrase contains 2 words instead of expected 12. ',
+					),
+				).to.be.true;
 			});
 		});
 

--- a/test/utils/input/index.js
+++ b/test/utils/input/index.js
@@ -46,6 +46,7 @@ describe('input utils', () => {
 				data: null,
 			});
 			sandbox.stub(inputUtils, 'getPassphrase');
+			sandbox.stub(console, 'warn').returns('');
 			return sandbox.stub(inputUtils, 'getData');
 		});
 
@@ -79,6 +80,17 @@ describe('input utils', () => {
 				const result = await getInputsFromSources({});
 				expect(inputUtils.getPassphrase).not.to.be.called;
 				return expect(result.passphrase).to.be.null;
+			});
+
+			it('should print a warning if passphase not in mnemonic format', async () => {
+				const stdin = 'some passphrase';
+				inputUtils.getStdIn.resolves({
+					passphrase: stdin,
+				});
+				await getInputsFromSources(inputs);
+				expect(console.warn.getCall(0).args[0].trim()).to.equal(
+					'Warning: Passphrase contains 2 words instead of expected 12.',
+				);
 			});
 		});
 
@@ -115,6 +127,17 @@ describe('input utils', () => {
 				const result = await getInputsFromSources({});
 				expect(inputUtils.getPassphrase).not.to.be.called;
 				return expect(result.secondPassphrase).to.be.null;
+			});
+
+			it('should print a warning if passphase not in mnemonic format', async () => {
+				const stdin = 'some passphrase';
+				inputUtils.getStdIn.resolves({
+					secondPassphrase: stdin,
+				});
+				await getInputsFromSources(inputs);
+				expect(console.warn.getCall(0).args[0].trim()).to.equal(
+					'Warning: Passphrase contains 2 words instead of expected 12.',
+				);
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?

No warning when user inputs invalid mnemonic for passphrase. 

### How did I fix it?

Modified `getInputsFromSources` to fetch warnings from elements.

### How to test it?

Enter invalid mnemonic passphrase for any command that requires passphrase input.

### Review checklist

* The PR resolves #337
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
