### PR TITLE
Get account votes by address - Closes #643

### DIFF
--- a/docs/delegate.md
+++ b/docs/delegate.md
@@ -62,16 +62,16 @@ EXAMPLES
   delegate:voters lightcurve,4miners.net --limit 20 --offset 5 --sort publicKey:asc --pretty
 ```
 
-## `delegate:votes USERNAMES`
+## `delegate:votes ADDRESSES`
 
 Gets votes information for given delegate(s) from the blockchain.
 
 ```
 USAGE
-  $ lisk delegate:votes USERNAMES
+  $ lisk delegate:votes ADDRESSES
 
 ARGUMENTS
-  USERNAMES  Comma-separated username(s) to get information about.
+  ADDRESSES  Comma-separated address(es) to get information about.
 
 OPTIONS
   --limit          Limits the returned voters array by specified integer amount. Maximum is 100.
@@ -88,7 +88,7 @@ DESCRIPTION
   Gets voters information for given delegate(s) from the blockchain.
 
 EXAMPLES
-  delegate:votes lightcurve
-  delegate:votes lightcurve,4miners.net
-  delegate:votes lightcurve,4miners.net --limit 20 --offset 5 --sort balance:asc --pretty
+  delegate:votes 13133549779353512613L
+  delegate:votes 13133549779353512613L,16010222169256538112L
+  delegate:votes 13133549779353512613L,16010222169256538112L --limit 20 --offset 5 --sort balance:asc --pretty
 ```

--- a/src/commands/delegate/votes.js
+++ b/src/commands/delegate/votes.js
@@ -56,7 +56,7 @@ const processFlagInputs = (limitStr, offsetStr, sortStr) => {
 export default class VotesCommand extends BaseCommand {
 	async run() {
 		const {
-			args: { usernames },
+			args: { addresses },
 			flags: { limit: limitStr, offset: offsetStr, sort: sortStr },
 		} = this.parse(VotesCommand);
 
@@ -66,16 +66,16 @@ export default class VotesCommand extends BaseCommand {
 			sortStr,
 		);
 
-		const req = usernames.map(username => ({
+		const req = addresses.map(address => ({
 			query: {
-				username,
+				address,
 				limit: limit || 10,
 				offset: offset || 0,
 				sort: sort || 'balance:desc',
 			},
 			placeholder: {
-				username,
-				message: 'Delegate not found.',
+				address,
+				message: 'Account not found.',
 			},
 		}));
 		const client = getAPIClient(this.userConfig.api);
@@ -86,9 +86,9 @@ export default class VotesCommand extends BaseCommand {
 
 VotesCommand.args = [
 	{
-		name: 'usernames',
+		name: 'addresses',
 		required: true,
-		description: 'Comma-separated username(s) to get information about.',
+		description: 'Comma-separated address(es) to get information about.',
 		parse: input => input.split(',').filter(Boolean),
 	},
 ];
@@ -110,11 +110,11 @@ VotesCommand.flags = {
 };
 
 VotesCommand.description = `
-Gets votes information for given delegate(s) from the blockchain.
+Gets votes information for given account(s) from the blockchain.
 `;
 
 VotesCommand.examples = [
-	'delegate:votes lightcurve',
-	'delegate:votes lightcurve,4miners.net',
-	'delegate:votes lightcurve,4miners.net --limit 20 --offset 5 --sort balance:asc --pretty',
+	'delegate:votes 13133549779353512613L',
+	'delegate:votes 13133549779353512613L,16010222169256538112L',
+	'delegate:votes 13133549779353512613L,16010222169256538112L --limit 20 --offset 5 --sort balance:asc --pretty',
 ];

--- a/test/commands/delegate/votes.test.js
+++ b/test/commands/delegate/votes.test.js
@@ -32,14 +32,13 @@ describe('delegate:votes', () => {
 	};
 	const printMethodStub = sandbox.stub();
 	const apiClientStub = sandbox.stub();
-	const usernames = ['genesis_5', 'genesis_6'];
+	const addresses = ['13133549779353512613L', '16010222169256538112L'];
 	const queryResult = [
 		{
-			username: usernames[0],
+			address: addresses[0],
 			balance: '0',
 			publicKey:
 				'0a47b151eafe8cfc278721ba14305071cae727395abf4c00bd298296c851dab9',
-			address: '10730473708113756935L',
 			votes: [
 				{
 					balance: '999999999999',
@@ -68,11 +67,11 @@ describe('delegate:votes', () => {
 			})
 			.it('should throw an error when arg is not provided');
 
-		describe('delegate:votes delegate', () => {
+		describe('delegate:votes account', () => {
 			setupTest()
 				.stub(query, 'default', sandbox.stub().resolves(queryResult))
-				.command(['delegate:votes', usernames[0]])
-				.it('should get delegate votes and display as an array', () => {
+				.command(['delegate:votes', addresses[0]])
+				.it('should get account votes and display as an array', () => {
 					expect(api.default).to.be.calledWithExactly(apiConfig);
 					expect(query.default).to.be.calledWithExactly(
 						apiClientStub,
@@ -80,12 +79,12 @@ describe('delegate:votes', () => {
 						[
 							{
 								query: {
-									username: usernames[0],
+									address: addresses[0],
 									...defaultQuery,
 								},
 								placeholder: {
-									username: usernames[0],
-									message: 'Delegate not found.',
+									address: addresses[0],
+									message: 'Account not found.',
 								},
 							},
 						],
@@ -94,13 +93,13 @@ describe('delegate:votes', () => {
 				});
 		});
 
-		describe('delegate:votes delegates', () => {
-			const usernamesWithEmpty = ['genesis_4', ''];
+		describe('delegate:votes accounts', () => {
+			const addressesWithEmpty = ['13133549779353512613L', ''];
 
 			setupTest()
 				.stub(query, 'default', sandbox.stub().resolves(queryResult))
-				.command(['delegate:votes', usernames.join(',')])
-				.it('should get delegates votes and display as an array', () => {
+				.command(['delegate:votes', addresses.join(',')])
+				.it('should get account votes and display as an array', () => {
 					expect(api.default).to.be.calledWithExactly(apiConfig);
 					expect(query.default).to.be.calledWithExactly(
 						apiClientStub,
@@ -108,22 +107,22 @@ describe('delegate:votes', () => {
 						[
 							{
 								query: {
-									username: usernames[0],
+									address: addresses[0],
 									...defaultQuery,
 								},
 								placeholder: {
-									username: usernames[0],
-									message: 'Delegate not found.',
+									address: addresses[0],
+									message: 'Account not found.',
 								},
 							},
 							{
 								query: {
-									username: usernames[1],
+									address: addresses[1],
 									...defaultQuery,
 								},
 								placeholder: {
-									username: usernames[1],
-									message: 'Delegate not found.',
+									address: addresses[1],
+									message: 'Account not found.',
 								},
 							},
 						],
@@ -133,9 +132,9 @@ describe('delegate:votes', () => {
 
 			setupTest()
 				.stub(query, 'default', sandbox.stub().resolves(queryResult))
-				.command(['delegate:votes', usernamesWithEmpty.join(',')])
+				.command(['delegate:votes', addressesWithEmpty.join(',')])
 				.it(
-					'should get delegates votes only using non-empty args and display as an array',
+					'should get account votes only using non-empty args and display as an array',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
 						expect(query.default).to.be.calledWithExactly(
@@ -144,12 +143,12 @@ describe('delegate:votes', () => {
 							[
 								{
 									query: {
-										username: usernamesWithEmpty[0],
+										address: addressesWithEmpty[0],
 										...defaultQuery,
 									},
 									placeholder: {
-										username: usernamesWithEmpty[0],
-										message: 'Delegate not found.',
+										address: addressesWithEmpty[0],
+										message: 'Account not found.',
 									},
 								},
 							],
@@ -161,7 +160,7 @@ describe('delegate:votes', () => {
 
 		describe('delegate:votes --limit=xxx', () => {
 			setupTest()
-				.command(['delegate:votes', usernames[0], '--limit=wronglimit'])
+				.command(['delegate:votes', addresses[0], '--limit=wronglimit'])
 				.catch(error => {
 					return expect(error.message).to.contain(
 						'Limit must be an integer and greater than 0',
@@ -170,7 +169,7 @@ describe('delegate:votes', () => {
 				.it('should throw an error when limit is not a valid integer');
 
 			setupTest()
-				.command(['delegate:votes', usernames[0], '--limit=0'])
+				.command(['delegate:votes', addresses[0], '--limit=0'])
 				.catch(error => {
 					return expect(error.message).to.contain(
 						'Limit must be an integer and greater than 0',
@@ -179,7 +178,7 @@ describe('delegate:votes', () => {
 				.it('should throw an error when limit is 0');
 
 			setupTest()
-				.command(['delegate:votes', usernames[0], '--limit=101'])
+				.command(['delegate:votes', addresses[0], '--limit=101'])
 				.catch(error => {
 					return expect(error.message).to.contain(
 						'Maximum limit amount is 100',
@@ -189,8 +188,8 @@ describe('delegate:votes', () => {
 
 			setupTest()
 				.stub(query, 'default', sandbox.stub().resolves(queryResult))
-				.command(['delegate:votes', usernames[0], '--limit=3'])
-				.it('should get votes for delegate with limit', () => {
+				.command(['delegate:votes', addresses[0], '--limit=3'])
+				.it('should get votes for account with limit', () => {
 					expect(api.default).to.be.calledWithExactly(apiConfig);
 					expect(query.default).to.be.calledWithExactly(
 						apiClientStub,
@@ -198,14 +197,14 @@ describe('delegate:votes', () => {
 						[
 							{
 								query: {
-									username: usernames[0],
+									address: addresses[0],
 									limit: 3,
 									offset: 0,
 									sort: 'balance:desc',
 								},
 								placeholder: {
-									username: usernames[0],
-									message: 'Delegate not found.',
+									address: addresses[0],
+									message: 'Account not found.',
 								},
 							},
 						],
@@ -217,7 +216,7 @@ describe('delegate:votes', () => {
 
 		describe('delegate:votes --offset=xxx', () => {
 			setupTest()
-				.command(['delegate:votes', usernames[0], '--offset=wrongoffset'])
+				.command(['delegate:votes', addresses[0], '--offset=wrongoffset'])
 				.catch(error => {
 					return expect(error.message).to.contain(
 						'Offset must be an integer and greater than or equal to 0',
@@ -226,7 +225,7 @@ describe('delegate:votes', () => {
 				.it('should throw an error when offset is not a valid integer');
 
 			setupTest()
-				.command(['delegate:votes', usernames[0], '--offset=-1'])
+				.command(['delegate:votes', addresses[0], '--offset=-1'])
 				.catch(error => {
 					return expect(error.message).to.contain(
 						'Offset must be an integer and greater than or equal to 0',
@@ -236,8 +235,8 @@ describe('delegate:votes', () => {
 
 			setupTest()
 				.stub(query, 'default', sandbox.stub().resolves(queryResult))
-				.command(['delegate:votes', usernames[0], '--offset=1'])
-				.it('should get votes for delegate with offset', () => {
+				.command(['delegate:votes', addresses[0], '--offset=1'])
+				.it('should get votes for account with offset', () => {
 					expect(api.default).to.be.calledWithExactly(apiConfig);
 					expect(query.default).to.be.calledWithExactly(
 						apiClientStub,
@@ -245,14 +244,14 @@ describe('delegate:votes', () => {
 						[
 							{
 								query: {
-									username: usernames[0],
+									address: addresses[0],
 									limit: 10,
 									offset: 1,
 									sort: 'balance:desc',
 								},
 								placeholder: {
-									username: usernames[0],
-									message: 'Delegate not found.',
+									address: addresses[0],
+									message: 'Account not found.',
 								},
 							},
 						],
@@ -264,7 +263,7 @@ describe('delegate:votes', () => {
 
 		describe('delegate:votes --sort=xxx', () => {
 			setupTest()
-				.command(['delegate:votes', usernames[0], '--sort=wrongsort'])
+				.command(['delegate:votes', addresses[0], '--sort=wrongsort'])
 				.catch(error => {
 					return expect(error.message).to.contain(
 						'Sort must be one of: balance:asc, balance:desc, username:asc, username:desc',
@@ -274,8 +273,8 @@ describe('delegate:votes', () => {
 
 			setupTest()
 				.stub(query, 'default', sandbox.stub().resolves(queryResult))
-				.command(['delegate:votes', usernames[0], '--sort=balance:asc'])
-				.it('should get sorted votes for delegate', () => {
+				.command(['delegate:votes', addresses[0], '--sort=balance:asc'])
+				.it('should get sorted votes for account', () => {
 					expect(api.default).to.be.calledWithExactly(apiConfig);
 					expect(query.default).to.be.calledWithExactly(
 						apiClientStub,
@@ -283,14 +282,14 @@ describe('delegate:votes', () => {
 						[
 							{
 								query: {
-									username: usernames[0],
+									address: addresses[0],
 									limit: 10,
 									offset: 0,
 									sort: 'balance:asc',
 								},
 								placeholder: {
-									username: usernames[0],
-									message: 'Delegate not found.',
+									address: addresses[0],
+									message: 'Account not found.',
 								},
 							},
 						],


### PR DESCRIPTION
### What was the problem?

delegate:votes command was by username. should be able to search by address instead of username to get votes for all accounts, not only delegates.

### How did I fix it?

change from username --> address

### How to test it?

npm test 
or
./bin/run delegate:votes 1601022216925653812L

### Review checklist

* The PR resolves #643 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
