### PR TITLE
Add cmd get transactions by senderID and state filters - Closes #648

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -412,26 +412,32 @@ ARGUMENTS
   IDS  Comma-separated transaction ID(s) to get information about.
 
 OPTIONS
-  -j, --[no-]json                   Prints output in JSON format. You can change the default behaviour in your
-                                    config.json file.
+  -j, --[no-]json
+      Prints output in JSON format. You can change the default behaviour in your config.json file.
 
-  -s, --state=unsigned|unprocessed  Get transactions based on a given state. Possible values for the state are
-                                    'unsigned' and 'unprocessed'.
-                                    Examples:
-                                    - --state=unsigned
-                                    - --state=unprocessed
+  -s, --state=unsigned|unprocessed
+      Get transactions based on a given state. Possible values for the state are 'unsigned' and 'unprocessed'.
+      	Examples:
+      	- --state=unsigned
+      	- --state=unprocessed
 
-  --limit=limit                     [default: 20] Limits the returned transactions array by specified integer amount.
-                                    Maximum is 100.
+  --limit=limit
+      [default: 10] Limits the returned transactions array by specified integer amount. Maximum is 100.
 
-  --offset=offset                   [default: 0] Offsets the returned transactions array by specified integer amount.
+  --offset=offset
+      [default: 0] Offsets the returned transactions array by specified integer amount.
 
-  --[no-]pretty                     Prints JSON in pretty format rather than condensed. Has no effect if the output is
-                                    set to table. You can change the default behaviour in your config.json file.
+  --[no-]pretty
+      Prints JSON in pretty format rather than condensed. Has no effect if the output is set to table. You can change the
+      default behaviour in your config.json file.
 
-  --senderId=senderId               Get transactions based by senderId which is sender's lisk address'.
-                                    Examples:
-                                    - --senderId=12668885769632475474L
+  --sender-id=sender-id
+      Get transactions based by senderId which is sender's lisk address'.
+      	Examples:
+      	- --sender-id=12668885769632475474L
+
+  --sort=amount:asc|amount:desc|fee:asc|fee:desc|type:asc|type:desc|timestamp:asc|timestamp:desc
+      [default: timestamp:asc] Fields to sort results by.
 
 DESCRIPTION
   Gets transaction information from the blockchain.
@@ -440,7 +446,10 @@ EXAMPLES
   transaction:get 10041151099734832021
   transaction:get 10041151099734832021,1260076503909567890
   transaction:get 10041151099734832021,1260076503909567890 --state=unprocessed
-  transaction:get --state=unsigned --senderId=1813095620424213569L
+  transaction:get 10041151099734832021 --state=unsigned --sender-id=1813095620424213569L
+  transaction:get --state=unsigned --sender-id=1813095620424213569L
+  transaction:get --sender-id=1813095620424213569L
+  transaction:get --limit=10 --sort=amount:desc
   transaction:get --limit=10 --offset=5
 ```
 

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -421,8 +421,17 @@ OPTIONS
                                     - --state=unsigned
                                     - --state=unprocessed
 
+  --limit=limit                     [default: 20] Limits the returned transactions array by specified integer amount.
+                                    Maximum is 100.
+
+  --offset=offset                   [default: 0] Offsets the returned transactions array by specified integer amount.
+
   --[no-]pretty                     Prints JSON in pretty format rather than condensed. Has no effect if the output is
                                     set to table. You can change the default behaviour in your config.json file.
+
+  --senderId=senderId               Get transactions based by senderId which is sender's lisk address'.
+                                    Examples:
+                                    - --senderId=12668885769632475474L
 
 DESCRIPTION
   Gets transaction information from the blockchain.
@@ -431,6 +440,8 @@ EXAMPLES
   transaction:get 10041151099734832021
   transaction:get 10041151099734832021,1260076503909567890
   transaction:get 10041151099734832021,1260076503909567890 --state=unprocessed
+  transaction:get --state=unsigned --senderId=1813095620424213569L
+  transaction:get --limit=10 --offset=5
 ```
 
 ## `lisk transaction:sign [TRANSACTION]`

--- a/src/commands/transaction/get.js
+++ b/src/commands/transaction/get.js
@@ -92,7 +92,7 @@ export default class GetCommand extends BaseCommand {
 		}
 
 		if (txnState && ids) {
-			const reqTransactionIDs = ids.map(id => ({
+			const reqTransactionIds = ids.map(id => ({
 				query: {
 					limit: 1,
 					id,
@@ -103,7 +103,7 @@ export default class GetCommand extends BaseCommand {
 				},
 			}));
 
-			const results = await queryNode(client.node, txnState, reqTransactionIDs);
+			const results = await queryNode(client.node, txnState, reqTransactionIds);
 
 			return this.print(results);
 		}
@@ -191,10 +191,6 @@ export default class GetCommand extends BaseCommand {
 			},
 		};
 		const results = await query(client, 'transactions', req);
-
-		if (!Array.isArray(results)) {
-			return this.print(results);
-		}
 
 		return this.print(results);
 	}

--- a/src/commands/transaction/get.js
+++ b/src/commands/transaction/get.js
@@ -239,6 +239,7 @@ GetCommand.examples = [
 	'transaction:get 10041151099734832021,1260076503909567890',
 	'transaction:get 10041151099734832021,1260076503909567890 --state=unprocessed',
 	'transaction:get --state=unsigned --sender-id=1813095620424213569L',
+	'transaction:get 10041151099734832021 --state=unsigned --sender-id=1813095620424213569L',
 	'transaction:get --sender-id=1813095620424213569L',
 	'transaction:get --limit=10 --sort=amount:desc',
 	'transaction:get --limit=10 --offset=5',

--- a/src/commands/transaction/get.js
+++ b/src/commands/transaction/get.js
@@ -16,7 +16,7 @@
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
 import getAPIClient from '../../utils/api';
-import { query, handleResponse } from '../../utils/query';
+import { query, queryNodeTransaction } from '../../utils/query';
 
 const TRANSACTION_STATES = ['unsigned', 'unprocessed'];
 const SORT_OPTIONS = [
@@ -45,17 +45,6 @@ const stateFlag = {
 	- --state=unprocessed
 `,
 };
-
-const queryNode = async (client, txnState, parameters) =>
-	Promise.all(
-		parameters.map(param =>
-			client
-				.getTransactions(txnState, param.query)
-				.then(res =>
-					handleResponse('node/transactions', res, param.placeholder),
-				),
-		),
-	);
 
 export default class GetCommand extends BaseCommand {
 	async run() {
@@ -86,7 +75,11 @@ export default class GetCommand extends BaseCommand {
 				},
 			}));
 
-			const results = await queryNode(client.node, txnState, reqTxnSenderId);
+			const results = await queryNodeTransaction(
+				client.node,
+				txnState,
+				reqTxnSenderId,
+			);
 
 			return this.print(results);
 		}
@@ -103,7 +96,11 @@ export default class GetCommand extends BaseCommand {
 				},
 			}));
 
-			const results = await queryNode(client.node, txnState, reqTransactionIds);
+			const results = await queryNodeTransaction(
+				client.node,
+				txnState,
+				reqTransactionIds,
+			);
 
 			return this.print(results);
 		}
@@ -123,7 +120,11 @@ export default class GetCommand extends BaseCommand {
 				},
 			];
 
-			const results = await queryNode(client.node, txnState, reqWithSenderId);
+			const results = await queryNodeTransaction(
+				client.node,
+				txnState,
+				reqWithSenderId,
+			);
 
 			return this.print(results);
 		}
@@ -142,7 +143,11 @@ export default class GetCommand extends BaseCommand {
 				},
 			];
 
-			const results = await queryNode(client.node, txnState, reqByLimitOffset);
+			const results = await queryNodeTransaction(
+				client.node,
+				txnState,
+				reqByLimitOffset,
+			);
 
 			return this.print(results);
 		}

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -46,3 +46,14 @@ export const query = async (client, endpoint, parameters) =>
 		: client[endpoint]
 				.get(parameters.query)
 				.then(res => handleResponse(endpoint, res, parameters.placeholder));
+
+export const queryNodeTransaction = async (client, txnState, parameters) =>
+	Promise.all(
+		parameters.map(param =>
+			client
+				.getTransactions(txnState, param.query)
+				.then(res =>
+					handleResponse('node/transactions', res, param.placeholder),
+				),
+		),
+	);

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -26,7 +26,10 @@ export const handleResponse = (endpoint, res, placeholder) => {
 			}
 			throw new Error(`No ${endpoint} found using specified parameters.`);
 		}
-		return res.data;
+		if (res.data.length > 1) {
+			return res.data;
+		}
+		return res.data[0];
 	}
 	return res.data;
 };

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -26,7 +26,7 @@ export const handleResponse = (endpoint, res, placeholder) => {
 			}
 			throw new Error(`No ${endpoint} found using specified parameters.`);
 		}
-		return res.data[0];
+		return res.data;
 	}
 	return res.data;
 };

--- a/test/commands/transaction/get.test.js
+++ b/test/commands/transaction/get.test.js
@@ -308,22 +308,27 @@ describe('transaction:get', () => {
 			})
 			.it('should throw an error when incorrect value of state is provided');
 
+		setupTest()
+			.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
+			.command(['transaction:get', transactionId, '--state=unprocessed'])
+			.it(
+				'should get an unprocessed transaction’s info and display as an array.',
+				() => {
+					expect(api.default).to.be.calledWithExactly(apiConfig);
+					return expect(printMethodStub).to.be.calledWithExactly([
+						defaultGetTransactionsResponse.data,
+					]);
+				},
+			);
+
 		describe('transaction:get transactions --state=unprocessed', () => {
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
-				.command(['transaction:get', transactionId, '--state=unprocessed'])
-				.it(
-					'should get an unprocessed transaction’s info and display as an array.',
-					() => {
-						expect(api.default).to.be.calledWithExactly(apiConfig);
-						return expect(printMethodStub).to.be.calledWithExactly([
-							defaultGetTransactionsResponse.data,
-						]);
-					},
-				);
-
-			setupTest()
-				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
+				.stub(
+					queryHandler,
+					'queryNodeTransaction',
+					sandbox.stub().resolves(defaultGetTransactionsResponse),
+				)
 				.command([
 					'transaction:get',
 					transactionIdsWithEmpty.join(','),
@@ -333,6 +338,32 @@ describe('transaction:get', () => {
 					'should get transaction’s info for given ids and unsigned state.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
+						expect(queryHandler.queryNodeTransaction).to.be.calledWithExactly(
+							apiClientStubNode.node,
+							'unsigned',
+							[
+								{
+									query: {
+										id: '3520445367460290306',
+										limit: 1,
+									},
+									placeholder: {
+										id: '3520445367460290306',
+										message: 'Transaction not found.',
+									},
+								},
+								{
+									query: {
+										id: '2802325248134221536',
+										limit: 1,
+									},
+									placeholder: {
+										id: '2802325248134221536',
+										message: 'Transaction not found.',
+									},
+								},
+							],
+						);
 						return expect(printMethodStub).to.be.calledWithExactly([
 							defaultGetTransactionsResponse.data,
 						]);
@@ -343,6 +374,11 @@ describe('transaction:get', () => {
 		describe('transaction:get --state-unsigned --sender-id', () => {
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
+				.stub(
+					queryHandler,
+					'queryNodeTransaction',
+					sandbox.stub().resolves(defaultGetTransactionsResponse),
+				)
 				.command([
 					'transaction:get',
 					'--sender-id=12668885769632475474L',
@@ -352,6 +388,24 @@ describe('transaction:get', () => {
 					'should get a transaction’s info for a given sender’s address and state and display as an array.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
+						expect(queryHandler.queryNodeTransaction).to.be.calledWithExactly(
+							apiClientStubNode.node,
+							'unprocessed',
+							[
+								{
+									query: {
+										limit: '10',
+										offset: '0',
+										senderId: '12668885769632475474L',
+										sort: 'timestamp:desc',
+									},
+									placeholder: {
+										senderId: '12668885769632475474L',
+										message: 'Transaction not found.',
+									},
+								},
+							],
+						);
 						return expect(printMethodStub).to.be.calledWithExactly([
 							defaultGetTransactionsResponse.data,
 						]);
@@ -360,6 +414,11 @@ describe('transaction:get', () => {
 
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
+				.stub(
+					queryHandler,
+					'queryNodeTransaction',
+					sandbox.stub().resolves(defaultGetTransactionsResponse),
+				)
 				.command([
 					'transaction:get',
 					'3520445367460290306',
@@ -370,6 +429,24 @@ describe('transaction:get', () => {
 					'should get a transaction’s info for a given txn Id, sender’s address and state and display as an array.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
+						expect(queryHandler.queryNodeTransaction).to.be.calledWithExactly(
+							apiClientStubNode.node,
+							'unprocessed',
+							[
+								{
+									query: {
+										limit: 1,
+										id: '3520445367460290306',
+										senderId: '12668885769632475474L',
+									},
+									placeholder: {
+										senderId: '12668885769632475474L',
+										id: '3520445367460290306',
+										message: 'Transaction not found.',
+									},
+								},
+							],
+						);
 						return expect(printMethodStub).to.be.calledWithExactly([
 							defaultGetTransactionsResponse.data,
 						]);
@@ -378,11 +455,32 @@ describe('transaction:get', () => {
 
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
-				.command(['transaction:get', '--state=unprocessed', '--limit=10'])
+				.stub(
+					queryHandler,
+					'queryNodeTransaction',
+					sandbox.stub().resolves(defaultGetTransactionsResponse),
+				)
+				.command(['transaction:get', '--state=unprocessed', '--limit=50'])
 				.it(
 					'should get transactions for a given state without specified txn id and limited by limit flag.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
+						expect(queryHandler.queryNodeTransaction).to.be.calledWithExactly(
+							apiClientStubNode.node,
+							'unprocessed',
+							[
+								{
+									query: {
+										limit: '50',
+										offset: '0',
+										sort: 'timestamp:desc',
+									},
+									placeholder: {
+										message: 'No transactions found.',
+									},
+								},
+							],
+						);
 						return expect(printMethodStub).to.be.calledWithExactly([
 							defaultGetTransactionsResponse.data,
 						]);

--- a/test/commands/transaction/get.test.js
+++ b/test/commands/transaction/get.test.js
@@ -90,7 +90,7 @@ describe('transaction:get', () => {
 			.stub(api, 'default', sandbox.stub().returns(apiClientStub))
 			.stub(queryHandler, 'query', sandbox.stub().resolves(queryResult))
 			.command(['transaction:get', transactionIds.join(',')])
-			.it('should get two transactions’ info and display as an array', () => {
+			.it('should get two transactions’ info and display as an array.', () => {
 				expect(api.default).to.be.calledWithExactly(apiConfig);
 				expect(queryHandler.query).to.be.calledWithExactly(
 					apiClientStub,
@@ -126,7 +126,7 @@ describe('transaction:get', () => {
 			.stub(queryHandler, 'query', sandbox.stub().resolves(queryResult))
 			.command(['transaction:get', transactionIdsWithEmpty.join(',')])
 			.it(
-				'should get transactions info only using non-empty args and display as an array',
+				'should get transaction’s info only using non-empty args and display as an array.',
 				() => {
 					expect(api.default).to.be.calledWithExactly(apiConfig);
 					expect(queryHandler.query).to.be.calledWithExactly(
@@ -158,12 +158,13 @@ describe('transaction:get', () => {
 					return expect(printMethodStub).to.be.calledWithExactly(queryResult);
 				},
 			);
-		describe('transaction: get --sender-id', () => {
+
+		describe('transaction:get --sender-id', () => {
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStub))
 				.stub(queryHandler, 'query', sandbox.stub().resolves(queryResult))
 				.command(['transaction:get', '--sender-id=12668885769632475474L'])
-				.it('should get all transactions info limited by limit value', () => {
+				.it('should get all transactions for a given sender-id.', () => {
 					expect(api.default).to.be.calledWithExactly(apiConfig);
 					expect(queryHandler.query).to.be.calledWithExactly(
 						apiClientStub,
@@ -183,12 +184,13 @@ describe('transaction:get', () => {
 					return expect(printMethodStub).to.be.calledWithExactly(queryResult);
 				});
 		});
+
 		describe('transaction: get --limit --offset', () => {
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStub))
 				.stub(queryHandler, 'query', sandbox.stub().resolves(queryResult))
 				.command(['transaction:get', '--limit=10'])
-				.it('should get all transactions info limited by limit value', () => {
+				.it('should get all transactions info limited by limit value.', () => {
 					expect(api.default).to.be.calledWithExactly(apiConfig);
 					expect(queryHandler.query).to.be.calledWithExactly(
 						apiClientStub,
@@ -212,7 +214,7 @@ describe('transaction:get', () => {
 				.stub(queryHandler, 'query', sandbox.stub().resolves(queryResult))
 				.command(['transaction:get'])
 				.it(
-					'should get all transactions based on default value of limit(20) and offset(0).',
+					'should get all transactions based on default value of limit(10) and offset(0).',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
 						expect(queryHandler.query).to.be.calledWithExactly(
@@ -232,6 +234,7 @@ describe('transaction:get', () => {
 						return expect(printMethodStub).to.be.calledWithExactly(queryResult);
 					},
 				);
+
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStub))
 				.stub(
@@ -240,26 +243,29 @@ describe('transaction:get', () => {
 					sandbox.stub().resolves({ message: 'No transactions found.' }),
 				)
 				.command(['transaction:get', '--offset=10'])
-				.it('should return a message with no transactions found.', () => {
-					expect(api.default).to.be.calledWithExactly(apiConfig);
-					expect(queryHandler.query).to.be.calledWithExactly(
-						apiClientStub,
-						endpoint,
-						{
-							query: {
-								limit: '10',
-								offset: '10',
-								sort: 'timestamp:desc',
+				.it(
+					'should return a message that no transactions found when there are no transactions after a given offset value.',
+					() => {
+						expect(api.default).to.be.calledWithExactly(apiConfig);
+						expect(queryHandler.query).to.be.calledWithExactly(
+							apiClientStub,
+							endpoint,
+							{
+								query: {
+									limit: '10',
+									offset: '10',
+									sort: 'timestamp:desc',
+								},
+								placeholder: {
+									message: 'No transactions found.',
+								},
 							},
-							placeholder: {
-								message: 'No transactions found.',
-							},
-						},
-					);
-					return expect(printMethodStub).to.be.calledWithExactly({
-						message: 'No transactions found.',
-					});
-				});
+						);
+						return expect(printMethodStub).to.be.calledWithExactly({
+							message: 'No transactions found.',
+						});
+					},
+				);
 		});
 	});
 
@@ -302,12 +308,12 @@ describe('transaction:get', () => {
 			})
 			.it('should throw an error when incorrect value of state is provided');
 
-		describe('transaction: get transactions --state=unprocessed', () => {
+		describe('transaction:get transactions --state=unprocessed', () => {
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
 				.command(['transaction:get', transactionId, '--state=unprocessed'])
 				.it(
-					'should get a transaction’s info and display as an array for a state.',
+					'should get an unprocessed transaction’s info and display as an array.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
 						return expect(printMethodStub).to.be.calledWithExactly([
@@ -324,7 +330,7 @@ describe('transaction:get', () => {
 					'--state=unsigned',
 				])
 				.it(
-					'should get transaction’s info and display as an array for a state.',
+					'should get transaction’s info for given ids and unsigned state.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
 						return expect(printMethodStub).to.be.calledWithExactly([
@@ -334,7 +340,7 @@ describe('transaction:get', () => {
 				);
 		});
 
-		describe('transaction: get --state-unsigned --sender-id', () => {
+		describe('transaction:get --state-unsigned --sender-id', () => {
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
 				.command([
@@ -343,7 +349,7 @@ describe('transaction:get', () => {
 					'--state=unprocessed',
 				])
 				.it(
-					'should get a transaction’s info for a given senders address and state and display as an array.',
+					'should get a transaction’s info for a given sender’s address and state and display as an array.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
 						return expect(printMethodStub).to.be.calledWithExactly([
@@ -361,7 +367,7 @@ describe('transaction:get', () => {
 					'--state=unprocessed',
 				])
 				.it(
-					'should get a transaction’s info for a given txn Id, senders address and state and display as an array.',
+					'should get a transaction’s info for a given txn Id, sender’s address and state and display as an array.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
 						return expect(printMethodStub).to.be.calledWithExactly([
@@ -374,7 +380,7 @@ describe('transaction:get', () => {
 				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
 				.command(['transaction:get', '--state=unprocessed', '--limit=10'])
 				.it(
-					'should get transactions for a given state taking limit or offset or default.',
+					'should get transactions for a given state without specified txn id and limited by limit flag.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
 						return expect(printMethodStub).to.be.calledWithExactly([

--- a/test/commands/transaction/get.test.js
+++ b/test/commands/transaction/get.test.js
@@ -33,13 +33,6 @@ describe('transaction:get', () => {
 			.stub(config, 'getConfig', sandbox.stub().returns({ api: apiConfig }))
 			.stdout();
 
-	setupTest()
-		.command(['transaction:get'])
-		.catch(error => {
-			return expect(error.message).to.contain('Missing 1 required arg');
-		})
-		.it('should throw an error when arg is not provided');
-
 	describe('transaction:get transaction', () => {
 		const transactionId = '3520445367460290306';
 		const queryResult = {
@@ -84,10 +77,24 @@ describe('transaction:get', () => {
 			{
 				id: transactionIds[0],
 				type: 0,
+				height: 105,
 			},
 			{
 				id: transactionIds[1],
 				type: 3,
+				height: 1010,
+			},
+		];
+		const querySortResult = [
+			{
+				id: transactionIds[1],
+				type: 3,
+				height: 1010,
+			},
+			{
+				id: transactionIds[0],
+				type: 0,
+				height: 105,
 			},
 		];
 
@@ -163,6 +170,93 @@ describe('transaction:get', () => {
 					return expect(printMethodStub).to.be.calledWithExactly(queryResult);
 				},
 			);
+		describe('transaction: get --limit --offset', () => {
+			setupTest()
+				.stub(api, 'default', sandbox.stub().returns(apiClientStub))
+				.stub(queryHandler, 'query', sandbox.stub().resolves(queryResult))
+				.command(['transaction:get', '--limit=10'])
+				.it('should get all transactions info limited by limit value', () => {
+					expect(api.default).to.be.calledWithExactly(apiConfig);
+					expect(queryHandler.query).to.be.calledWithExactly(
+						apiClientStub,
+						endpoint,
+						{
+							query: {
+								limit: '10',
+								offset: '0',
+							},
+							placeholder: {
+								message: 'No transactions found.',
+							},
+						},
+					);
+					return expect(printMethodStub).to.be.calledWithExactly(
+						querySortResult,
+					);
+				});
+
+			setupTest()
+				.stub(api, 'default', sandbox.stub().returns(apiClientStub))
+				.stub(queryHandler, 'query', sandbox.stub().resolves(queryResult))
+				.command(['transaction:get'])
+				.it(
+					'should get all transactions based on default value of limit(20) and offset(0).',
+					() => {
+						expect(api.default).to.be.calledWithExactly(apiConfig);
+						expect(queryHandler.query).to.be.calledWithExactly(
+							apiClientStub,
+							endpoint,
+							{
+								query: {
+									limit: '20',
+									offset: '0',
+								},
+								placeholder: {
+									message: 'No transactions found.',
+								},
+							},
+						);
+						return expect(printMethodStub).to.be.calledWithExactly(
+							querySortResult,
+						);
+					},
+				);
+		});
+		setupTest()
+			.stub(api, 'default', sandbox.stub().returns(apiClientStub))
+			.stub(queryHandler, 'query', sandbox.stub().resolves(queryResult))
+			.command(['transaction:get', '--offset=10'])
+			.it('should get all transaction’s info and display.', () => {
+				expect(api.default).to.be.calledWithExactly(apiConfig);
+				return expect(printMethodStub).to.be.calledWithExactly(queryResult);
+			});
+		setupTest()
+			.stub(api, 'default', sandbox.stub().returns(apiClientStub))
+			.stub(
+				queryHandler,
+				'query',
+				sandbox.stub().resolves({ message: 'No transactions found.' }),
+			)
+			.command(['transaction:get', '--offset=10'])
+			.it('should return a message with no transactions found.', () => {
+				expect(api.default).to.be.calledWithExactly(apiConfig);
+				expect(queryHandler.query).to.be.calledWithExactly(
+					apiClientStub,
+					endpoint,
+					{
+						query: {
+							limit: '20',
+							offset: '10',
+						},
+						placeholder: {
+							message: 'No transactions found.',
+						},
+					},
+				);
+				return expect(printMethodStub).to.be.calledWithExactly({
+					message: 'No transactions found.',
+				});
+			});
 	});
 
 	describe('transaction:get transactions --state', () => {
@@ -194,45 +288,28 @@ describe('transaction:get', () => {
 			},
 		};
 
-		describe('transaction: get transactions --state-unprocessed', () => {
+		setupTest()
+			.command(['transaction:get', '--state=unsign', '--offset=1'])
+			.catch(error => {
+				return expect(error.message).to.contain(
+					'to be one of: unsigned, unprocessed',
+				);
+			})
+			.it('should throw an error when incorrect value of state is provided');
+
+		describe('transaction: get transactions --state=unprocessed', () => {
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
 				.command(['transaction:get', transactionId, '--state=unprocessed'])
-				.it('should get a transaction’s info and display as an array', () => {
-					expect(api.default).to.be.calledWithExactly(apiConfig);
-					return expect(printMethodStub).to.be.calledWithExactly([
-						defaultGetTransactionsResponse.data[0],
-					]);
-				});
-
-			setupTest()
-				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
-				.command([
-					'transaction:get',
-					transactionIdsWithEmpty.join(','),
-					'--state=unprocessed',
-				])
 				.it(
-					'should get transactions info only using non-empty args and display as an array',
+					'should get a transaction’s info and display as an array for a state.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
-						return expect(printMethodStub).to.be.calledWithExactly(
+						return expect(printMethodStub).to.be.calledWithExactly([
 							defaultGetTransactionsResponse.data,
-						);
+						]);
 					},
 				);
-		});
-
-		describe('transaction: get transactions --state-unsigned', () => {
-			setupTest()
-				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
-				.command(['transaction:get', transactionId, '--state=unsigned'])
-				.it('should get a transaction’s info and display as an array', () => {
-					expect(api.default).to.be.calledWithExactly(apiConfig);
-					return expect(printMethodStub).to.be.calledWithExactly([
-						defaultGetTransactionsResponse.data[0],
-					]);
-				});
 
 			setupTest()
 				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
@@ -242,12 +319,44 @@ describe('transaction:get', () => {
 					'--state=unsigned',
 				])
 				.it(
-					'should get transactions info only using non-empty args and display as an array',
+					'should get transaction’s info and display as an array for a state.',
 					() => {
 						expect(api.default).to.be.calledWithExactly(apiConfig);
-						return expect(printMethodStub).to.be.calledWithExactly(
+						return expect(printMethodStub).to.be.calledWithExactly([
 							defaultGetTransactionsResponse.data,
-						);
+						]);
+					},
+				);
+		});
+
+		describe('transaction: get --state-unsigned --senderID', () => {
+			setupTest()
+				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
+				.command([
+					'transaction:get',
+					'--senderId=12668885769632475474L',
+					'--state=unprocessed',
+				])
+				.it(
+					'should get a transaction’s info for a given senders address and state and display as an array.',
+					() => {
+						expect(api.default).to.be.calledWithExactly(apiConfig);
+						return expect(printMethodStub).to.be.calledWithExactly([
+							defaultGetTransactionsResponse.data,
+						]);
+					},
+				);
+
+			setupTest()
+				.stub(api, 'default', sandbox.stub().returns(apiClientStubNode))
+				.command(['transaction:get', '--state=unprocessed', '--limit=10'])
+				.it(
+					'should get transactions for a given state taking limit or offset or default.',
+					() => {
+						expect(api.default).to.be.calledWithExactly(apiConfig);
+						return expect(printMethodStub).to.be.calledWithExactly([
+							defaultGetTransactionsResponse.data,
+						]);
 					},
 				);
 		});

--- a/test/utils/query.js
+++ b/test/utils/query.js
@@ -132,7 +132,7 @@ describe('query utils', () => {
 			expect(apiClient.accounts.get).to.be.calledWithExactly(
 				defaultParameters.query,
 			);
-			return expect(queryResult).to.eventually.eql(response.data[0]);
+			return expect(queryResult).to.eventually.eql(response.data);
 		});
 	});
 

--- a/test/utils/query.js
+++ b/test/utils/query.js
@@ -13,7 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { query } from '../../src/utils/query';
+import { query, queryNodeTransaction } from '../../src/utils/query';
 
 describe('query utils', () => {
 	const defaultEndpoint = 'accounts';
@@ -213,6 +213,105 @@ describe('query utils', () => {
 		it('should call API client', () => {
 			defaultArrayParameters.forEach(param =>
 				expect(apiClient.accounts.get).to.be.calledWithExactly(param.query),
+			);
+			return Promise.resolve();
+		});
+	});
+
+	describe('query node transaction handler', () => {
+		const txnState = 'unprocessed';
+		const transactionParameters = {
+			query: {
+				id: 'transaction1',
+				limit: 1,
+			},
+		};
+		const transactionArray = [
+			{
+				query: {
+					id: 'transaction1',
+					limit: 1,
+				},
+			},
+		];
+
+		beforeEach(() => {
+			response = {
+				data: [
+					{
+						id: 'transaction1',
+					},
+				],
+			};
+			apiClient = {
+				node: {
+					getTransactions: sandbox.stub().resolves(response),
+				},
+			};
+			queryResult = queryNodeTransaction(
+				apiClient.node,
+				txnState,
+				transactionArray,
+			);
+			return Promise.resolve();
+		});
+
+		it('should call node API client and resolve to an object', () => {
+			expect(apiClient.node.getTransactions).to.be.calledWithExactly(
+				txnState,
+				transactionParameters.query,
+			);
+			return expect(queryResult).to.eventually.eql(response.data);
+		});
+	});
+
+	describe('an array of parameters objects is provided to query node transaction', () => {
+		const txnState = 'unsigned';
+		const transactionArray = [
+			{
+				query: {
+					id: 'transaction1',
+					limit: 1,
+				},
+			},
+			{
+				query: {
+					id: 'transaction2',
+					limit: 1,
+				},
+			},
+		];
+
+		beforeEach(() => {
+			response = {
+				data: [
+					{
+						id: 'transaction1',
+					},
+					{
+						id: 'transaction2',
+					},
+				],
+			};
+			apiClient = {
+				node: {
+					getTransactions: sandbox.stub().resolves(response),
+				},
+			};
+			queryResult = queryNodeTransaction(
+				apiClient.node,
+				txnState,
+				transactionArray,
+			);
+			return Promise.resolve();
+		});
+
+		it('should call getTransaction handler of node API client', () => {
+			transactionArray.forEach(param =>
+				expect(apiClient.node.getTransactions).to.be.calledWithExactly(
+					txnState,
+					param.query,
+				),
 			);
 			return Promise.resolve();
 		});

--- a/test/utils/query.js
+++ b/test/utils/query.js
@@ -136,6 +136,37 @@ describe('query utils', () => {
 		});
 	});
 
+	describe('when the response is an array with more than 1 records', () => {
+		beforeEach(() => {
+			response = {
+				data: [
+					{
+						id: 'someid',
+						address: 'address',
+					},
+					{
+						id: 'someid',
+						address: 'address',
+					},
+				],
+			};
+			apiClient = {
+				accounts: {
+					get: sandbox.stub().resolves(response),
+				},
+			};
+			queryResult = query(apiClient, defaultEndpoint, defaultParameters);
+			return Promise.resolve();
+		});
+
+		it('should call API client and resolve to an array', () => {
+			expect(apiClient.accounts.get).to.be.calledWithExactly(
+				defaultParameters.query,
+			);
+			return expect(queryResult).to.eventually.eql(response.data);
+		});
+	});
+
 	describe('when the response is an object', () => {
 		beforeEach(() => {
 			response = {

--- a/test/utils/query.js
+++ b/test/utils/query.js
@@ -132,7 +132,7 @@ describe('query utils', () => {
 			expect(apiClient.accounts.get).to.be.calledWithExactly(
 				defaultParameters.query,
 			);
-			return expect(queryResult).to.eventually.eql(response.data);
+			return expect(queryResult).to.eventually.eql(response.data[0]);
 		});
 	});
 


### PR DESCRIPTION
### Description

Add command to get transactions based on `senderID`, `default`, `limit` and `offset` values.

Also related to #600 

Example,
`lisk transaction:get --sender-id=14523483941411160698L --state=unsigned`
`lisk transaction:get 7397859286435869218 --state=unprocessed`
`lisk transaction:get --limit=10 --offset=15`
`lisk transaction:get`

### Review checklist

* The PR resolves #648 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
