### PR TITLE
Update lisk-elements version - Closes #676

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,32 +5,44 @@
 	"requires": true,
 	"dependencies": {
 		"@liskhq/lisk-api-client": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@liskhq/lisk-api-client/-/lisk-api-client-1.1.1.tgz",
-			"integrity": "sha512-31qdMG55VCicQzKzk+2RAsIZwEt2o41VDOb1CnBChBvG8lKBAKBl7yrYlzRHAegvM6A3XQ0X9o8HmRha4Ah4qg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@liskhq/lisk-api-client/-/lisk-api-client-2.0.0.tgz",
+			"integrity": "sha512-HmIaV6tsEsedHGrgrn9vU6rTZ6pwpE5XylxkUPPRkeNVV3/vTfPWEzoKcyp9TrWBnsnpebmn56GsGzxQ8EA0EQ==",
 			"requires": {
-				"@liskhq/lisk-constants": "1.1.1",
-				"axios": "0.18.0"
+				"@types/node": "10.10.1",
+				"@types/verror": "1.10.3",
+				"axios": "0.18.0",
+				"verror": "1.10.0"
 			}
 		},
 		"@liskhq/lisk-constants": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@liskhq/lisk-constants/-/lisk-constants-1.1.1.tgz",
-			"integrity": "sha512-XWnTk77cWMIsUyjK2GdpzLWU69qG0O0QaIbN4zL9Jp4l5vl0QLp/SSIBwxSb36pjQW6EBNLjuV++h5B4HoIoKg=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@liskhq/lisk-constants/-/lisk-constants-1.2.0.tgz",
+			"integrity": "sha512-B/1Si1eT4wOe7AaInklfT2SLenLm7U9CyfNnjaZs423Hi5Vw5xjP7KkM2nJTkqd6EUF/SJARKU/eK1R/qq0uDw==",
+			"requires": {
+				"@types/node": "10.10.1"
+			}
 		},
 		"@liskhq/lisk-cryptography": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@liskhq/lisk-cryptography/-/lisk-cryptography-1.1.1.tgz",
-			"integrity": "sha512-uwChUS+Hzo56Ar1P8M+fXjBbdgZflbJoxZbJ7cp7U1IH/ZsTj53GlvcQWWc/fYSq0aN2INboW5wHOTtPObnOcw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@liskhq/lisk-cryptography/-/lisk-cryptography-2.0.0.tgz",
+			"integrity": "sha512-ytW7dLebHjnOr3jsCe8asoTGencsRVPncwh+JTn+rrEl3k0UVEx3WrPdKnAfU0mHnWc3CWBf9kh2huyYnHlcdw==",
 			"requires": {
-				"@liskhq/lisk-constants": "1.1.1",
+				"@types/ed2curve": "0.2.2",
+				"@types/node": "10.12.0",
 				"browserify-bignum": "1.3.0-2",
 				"buffer-reverse": "1.0.1",
 				"ed2curve": "0.2.1",
+				"sodium-native": "2.2.1",
 				"tweetnacl": "1.0.0",
 				"varuint-bitcoin": "1.1.0"
 			},
 			"dependencies": {
+				"@types/node": {
+					"version": "10.12.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
+					"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
+				},
 				"tweetnacl": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
@@ -39,20 +51,22 @@
 			}
 		},
 		"@liskhq/lisk-passphrase": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@liskhq/lisk-passphrase/-/lisk-passphrase-1.1.1.tgz",
-			"integrity": "sha512-AcQDHHsNWtIyJ6TJ2IpDQ7K3ovv7RAx4/97pcCUP0oDfJ3kTlK74siF4bm+tIC3R0BHmZeqwf+EbU3dWzLNJrw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@liskhq/lisk-passphrase/-/lisk-passphrase-2.0.0.tgz",
+			"integrity": "sha512-2PKboQPq75fuP/9jlAU4GJFfbz4hD9vkwqmZfScMCu7mUdaTcLF77J+nvFkf5T/CApQZU125oCGY+9loo5FqLw==",
 			"requires": {
+				"@types/bip39": "2.4.0",
+				"@types/node": "10.10.1",
 				"bip39": "2.5.0"
 			}
 		},
 		"@liskhq/lisk-transactions": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@liskhq/lisk-transactions/-/lisk-transactions-1.1.1.tgz",
-			"integrity": "sha512-GwAw+1fbc+SsB4NMJOkztVCvPxtJ8X3FQTfz+QU1BWD+opYV/RlERZVNs6A3J8DZHHwTm29rOwkcbn+Jtc8Sew==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@liskhq/lisk-transactions/-/lisk-transactions-2.0.0.tgz",
+			"integrity": "sha512-usUn3PbDN9R8FjhAmhl8ZKX72vGYzurmXYn5Qa4ekH2QKlgIhysPDs4yFuvcPR8BwqRNeYR1zOwPFzaWeXH8Bg==",
 			"requires": {
-				"@liskhq/lisk-constants": "1.1.1",
-				"@liskhq/lisk-cryptography": "1.1.1",
+				"@liskhq/lisk-cryptography": "2.0.0",
+				"@types/node": "10.10.1",
 				"ajv": "6.5.3",
 				"ajv-merge-patch": "4.1.0",
 				"browserify-bignum": "1.3.0-2"
@@ -274,7 +288,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@types/bip39/-/bip39-2.4.0.tgz",
 			"integrity": "sha512-qxJBGh55SPbSGv+91D6H3WOR8vKdA/p8Oc58oK/DTbORgjO6Ebuo8MRzdy2OWi+dw/lxtX4VWJkkCUTSQvhAnw==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -292,6 +305,21 @@
 			"dev": true,
 			"requires": {
 				"@types/chai": "*"
+			}
+		},
+		"@types/ed2curve": {
+			"version": "0.2.2",
+			"resolved": "http://registry.npmjs.org/@types/ed2curve/-/ed2curve-0.2.2.tgz",
+			"integrity": "sha512-G1sTX5xo91ydevQPINbL2nfgVAj/s1ZiqZxC8OCWduwu+edoNGUm5JXtTkg9F3LsBZbRI46/0HES4CPUE2wc9g==",
+			"requires": {
+				"tweetnacl": "^1.0.0"
+			},
+			"dependencies": {
+				"tweetnacl": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+					"integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+				}
 			}
 		},
 		"@types/expect": {
@@ -352,8 +380,7 @@
 		"@types/node": {
 			"version": "10.10.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
-			"integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA==",
-			"dev": true
+			"integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA=="
 		},
 		"@types/rx": {
 			"version": "4.1.1",
@@ -517,6 +544,11 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@types/verror": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.3.tgz",
+			"integrity": "sha512-7Jz0MPsW2pWg5dJfEp9nJYI0RDCYfgjg2wIo5HfQ8vOJvUq0/BxT7Mv2wNQvkKBmV9uT++6KF3reMnLmh/0HrA=="
 		},
 		"ajv": {
 			"version": "5.5.2",
@@ -1371,8 +1403,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "3.1.0",
@@ -1748,8 +1779,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fancy-test": {
 			"version": "1.4.0",
@@ -2557,6 +2587,12 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"optional": true
 		},
 		"inquirer": {
 			"version": "6.2.0",
@@ -3548,6 +3584,12 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
+		"nan": {
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"optional": true
+		},
 		"nanomatch": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
@@ -3606,6 +3648,12 @@
 				"path-to-regexp": "^1.7.0",
 				"text-encoding": "^0.6.4"
 			}
+		},
+		"node-gyp-build": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.5.0.tgz",
+			"integrity": "sha512-qjEE8eIWVyqZhkAFUzytGpOGvLHeX5kXBB6MYyTOCPZBrBlsLyXAAzTsp/hWMbVlg8kVpzDJCZZowIrnKpwmqQ==",
+			"optional": true
 		},
 		"node-uuid": {
 			"version": "1.4.8",
@@ -6238,6 +6286,17 @@
 				"hoek": "0.9.x"
 			}
 		},
+		"sodium-native": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.1.tgz",
+			"integrity": "sha512-3CfftYV2ATXQFMIkLOvcNUk/Ma+lran0855j5Z/HEjUkSTzjLZi16CK362udOoNVrwn/TwGV8bKEt5OylsFrQA==",
+			"optional": true,
+			"requires": {
+				"ini": "^1.3.5",
+				"nan": "^2.4.0",
+				"node-gyp-build": "^3.0.0"
+			}
+		},
 		"sort-keys": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -6988,7 +7047,6 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -6998,8 +7056,7 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -104,11 +104,11 @@
 		"/default_config.json"
 	],
 	"dependencies": {
-		"@liskhq/lisk-api-client": "1.1.1",
-		"@liskhq/lisk-constants": "1.1.1",
-		"@liskhq/lisk-cryptography": "1.1.1",
-		"@liskhq/lisk-passphrase": "1.1.1",
-		"@liskhq/lisk-transactions": "1.1.1",
+		"@liskhq/lisk-api-client": "2.0.0",
+		"@liskhq/lisk-constants": "1.2.0",
+		"@liskhq/lisk-cryptography": "2.0.0",
+		"@liskhq/lisk-passphrase": "2.0.0",
+		"@liskhq/lisk-transactions": "2.0.0",
 		"@oclif/command": "1.5.0",
 		"@oclif/config": "1.7.4",
 		"@oclif/errors": "1.2.0",

--- a/src/commands/account/create.js
+++ b/src/commands/account/create.js
@@ -14,7 +14,7 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BaseCommand from '../../base';
 import { createMnemonicPassphrase } from '../../utils/mnemonic';
 

--- a/src/commands/account/get.js
+++ b/src/commands/account/get.js
@@ -14,7 +14,7 @@
  *
  */
 import BaseCommand from '../../base';
-import getAPIClient from '../../utils/api';
+import { getAPIClient } from '../../utils/api';
 import { query } from '../../utils/query';
 
 export default class GetCommand extends BaseCommand {

--- a/src/commands/account/show.js
+++ b/src/commands/account/show.js
@@ -13,11 +13,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
-import getInputsFromSources from '../../utils/input';
-import commonFlags from '../../utils/flags';
+import { getInputsFromSources } from '../../utils/input';
+import { flags as commonFlags } from '../../utils/flags';
 
 const processInput = ({ passphrase }) => {
 	const { privateKey, publicKey } = cryptography.getKeys(passphrase);

--- a/src/commands/block/get.js
+++ b/src/commands/block/get.js
@@ -14,7 +14,7 @@
  *
  */
 import BaseCommand from '../../base';
-import getAPIClient from '../../utils/api';
+import { getAPIClient } from '../../utils/api';
 import { query } from '../../utils/query';
 
 export default class GetCommand extends BaseCommand {

--- a/src/commands/config/set.js
+++ b/src/commands/config/set.js
@@ -14,7 +14,7 @@
  *
  */
 import url from 'url';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BaseCommand from '../../base';
 import {
 	CONFIG_VARIABLES,

--- a/src/commands/delegate/get.js
+++ b/src/commands/delegate/get.js
@@ -14,7 +14,7 @@
  *
  */
 import BaseCommand from '../../base';
-import getAPIClient from '../../utils/api';
+import { getAPIClient } from '../../utils/api';
 import { query } from '../../utils/query';
 
 export default class GetCommand extends BaseCommand {

--- a/src/commands/delegate/voters.js
+++ b/src/commands/delegate/voters.js
@@ -15,7 +15,7 @@
  */
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
-import getAPIClient from '../../utils/api';
+import { getAPIClient } from '../../utils/api';
 import { query } from '../../utils/query';
 import { SORT_FIELDS } from '../../utils/constants';
 

--- a/src/commands/delegate/votes.js
+++ b/src/commands/delegate/votes.js
@@ -15,7 +15,7 @@
  */
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
-import getAPIClient from '../../utils/api';
+import { getAPIClient } from '../../utils/api';
 import { query } from '../../utils/query';
 import { SORT_FIELDS } from '../../utils/constants';
 

--- a/src/commands/message/decrypt.js
+++ b/src/commands/message/decrypt.js
@@ -14,11 +14,11 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BaseCommand from '../../base';
 import { ValidationError } from '../../utils/error';
-import getInputsFromSources from '../../utils/input';
-import commonFlags from '../../utils/flags';
+import { getInputsFromSources } from '../../utils/input';
+import { flags as commonFlags } from '../../utils/flags';
 
 const processInputs = (nonce, senderPublicKey, message) => ({
 	passphrase,

--- a/src/commands/message/encrypt.js
+++ b/src/commands/message/encrypt.js
@@ -14,11 +14,11 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BaseCommand from '../../base';
 import { ValidationError } from '../../utils/error';
-import getInputsFromSources from '../../utils/input';
-import commonFlags from '../../utils/flags';
+import { getInputsFromSources } from '../../utils/input';
+import { flags as commonFlags } from '../../utils/flags';
 
 const processInputs = (recipientPublicKey, message) => ({
 	passphrase,

--- a/src/commands/message/sign.js
+++ b/src/commands/message/sign.js
@@ -14,11 +14,11 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BaseCommand from '../../base';
 import { ValidationError } from '../../utils/error';
-import getInputsFromSources from '../../utils/input';
-import commonFlags from '../../utils/flags';
+import { getInputsFromSources } from '../../utils/input';
+import { flags as commonFlags } from '../../utils/flags';
 
 const processInputs = message => ({ passphrase, data }) =>
 	cryptography.signMessageWithPassphrase(message || data, passphrase);

--- a/src/commands/message/verify.js
+++ b/src/commands/message/verify.js
@@ -14,11 +14,11 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BaseCommand from '../../base';
 import { ValidationError } from '../../utils/error';
-import getInputsFromSources from '../../utils/input';
-import commonFlags from '../../utils/flags';
+import { getInputsFromSources } from '../../utils/input';
+import { flags as commonFlags } from '../../utils/flags';
 
 const processInputs = (publicKey, signature, message) => ({ data }) => ({
 	verified: cryptography.verifyMessageWithPublicKey({

--- a/src/commands/node/forging.js
+++ b/src/commands/node/forging.js
@@ -14,11 +14,11 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import transactions from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 import BaseCommand from '../../base';
-import commonFlags from '../../utils/flags';
-import getAPIClient from '../../utils/api';
-import getInputsFromSources from '../../utils/input';
+import { flags as commonFlags } from '../../utils/flags';
+import { getAPIClient } from '../../utils/api';
+import { getInputsFromSources } from '../../utils/input';
 
 const STATUS_ENABLE = 'enable';
 const STATUS_DISABLE = 'disable';

--- a/src/commands/node/get.js
+++ b/src/commands/node/get.js
@@ -15,7 +15,7 @@
  */
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
-import getAPIClient from '../../utils/api';
+import { getAPIClient } from '../../utils/api';
 
 export default class GetCommand extends BaseCommand {
 	async run() {

--- a/src/commands/passphrase/decrypt.js
+++ b/src/commands/passphrase/decrypt.js
@@ -14,11 +14,12 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BaseCommand from '../../base';
 import { ValidationError } from '../../utils/error';
-import commonFlags from '../../utils/flags';
-import getInputsFromSources, {
+import { flags as commonFlags } from '../../utils/flags';
+import {
+	getInputsFromSources,
 	getFirstLineFromString,
 } from '../../utils/input';
 

--- a/src/commands/passphrase/encrypt.js
+++ b/src/commands/passphrase/encrypt.js
@@ -14,10 +14,10 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BaseCommand from '../../base';
-import commonFlags from '../../utils/flags';
-import getInputsFromSources from '../../utils/input';
+import { flags as commonFlags } from '../../utils/flags';
+import { getInputsFromSources } from '../../utils/input';
 
 const outputPublicKeyOptionDescription =
 	'Includes the public key in the output. This option is provided for the convenience of node operators.';

--- a/src/commands/signature/broadcast.js
+++ b/src/commands/signature/broadcast.js
@@ -16,7 +16,7 @@
 import BaseCommand from '../../base';
 import { ValidationError } from '../../utils/error';
 import { getStdIn } from '../../utils/input/utils';
-import getAPIClient from '../../utils/api';
+import { getAPIClient } from '../../utils/api';
 
 const getSignatureInput = async () => {
 	try {

--- a/src/commands/signature/create.js
+++ b/src/commands/signature/create.js
@@ -13,14 +13,14 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import transactions from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
 import { getStdIn } from '../../utils/input/utils';
 import { ValidationError } from '../../utils/error';
-import parseTransactionString from '../../utils/transactions';
-import getInputsFromSources from '../../utils/input';
-import commonFlags from '../../utils/flags';
+import { parseTransactionString } from '../../utils/transactions';
+import { getInputsFromSources } from '../../utils/input';
+import { flags as commonFlags } from '../../utils/flags';
 
 const getTransactionInput = async () => {
 	try {

--- a/src/commands/transaction/broadcast.js
+++ b/src/commands/transaction/broadcast.js
@@ -14,10 +14,10 @@
  *
  */
 import BaseCommand from '../../base';
-import parseTransactionString from '../../utils/transactions';
+import { parseTransactionString } from '../../utils/transactions';
 import { ValidationError } from '../../utils/error';
 import { getStdIn } from '../../utils/input/utils';
-import getAPIClient from '../../utils/api';
+import { getAPIClient } from '../../utils/api';
 
 const getTransactionInput = async () => {
 	try {

--- a/src/commands/transaction/create.js
+++ b/src/commands/transaction/create.js
@@ -15,7 +15,7 @@
  */
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
-import commonFlags from '../../utils/flags';
+import { flags as commonFlags } from '../../utils/flags';
 import TransferCommand from './create/transfer';
 import SecondPassphraseCommand from './create/second-passphrase';
 import VoteCommand from './create/vote';

--- a/src/commands/transaction/create/delegate.js
+++ b/src/commands/transaction/create/delegate.js
@@ -14,10 +14,10 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import transactions from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 import BaseCommand from '../../../base';
-import commonFlags from '../../../utils/flags';
-import getInputsFromSources from '../../../utils/input';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getInputsFromSources } from '../../../utils/input';
 
 const processInputs = username => ({ passphrase, secondPassphrase }) =>
 	transactions.registerDelegate({

--- a/src/commands/transaction/create/multisignature.js
+++ b/src/commands/transaction/create/multisignature.js
@@ -14,10 +14,10 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import transactions from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 import BaseCommand from '../../../base';
-import commonFlags from '../../../utils/flags';
-import getInputsFromSources from '../../../utils/input';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getInputsFromSources } from '../../../utils/input';
 import { validateLifetime, validateMinimum } from '../../../utils/helpers';
 
 const processInputs = (lifetime, minimum, keysgroup) => ({

--- a/src/commands/transaction/create/second-passphrase.js
+++ b/src/commands/transaction/create/second-passphrase.js
@@ -14,10 +14,10 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import transactions from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 import BaseCommand from '../../../base';
-import commonFlags from '../../../utils/flags';
-import getInputsFromSources from '../../../utils/input';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getInputsFromSources } from '../../../utils/input';
 
 export const processInputs = () => ({ passphrase, secondPassphrase }) =>
 	transactions.registerSecondPassphrase({

--- a/src/commands/transaction/create/transfer.js
+++ b/src/commands/transaction/create/transfer.js
@@ -14,10 +14,10 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import transactions from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 import BaseCommand from '../../../base';
-import commonFlags from '../../../utils/flags';
-import getInputsFromSources from '../../../utils/input';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getInputsFromSources } from '../../../utils/input';
 
 const dataFlag = {
 	char: 'd',

--- a/src/commands/transaction/create/vote.js
+++ b/src/commands/transaction/create/vote.js
@@ -14,10 +14,10 @@
  *
  */
 import { flags as flagParser } from '@oclif/command';
-import transactions from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 import BaseCommand from '../../../base';
-import commonFlags from '../../../utils/flags';
-import getInputsFromSources from '../../../utils/input';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getInputsFromSources } from '../../../utils/input';
 import { getData } from '../../../utils/input/utils';
 import { ValidationError } from '../../../utils/error';
 

--- a/src/commands/transaction/get.js
+++ b/src/commands/transaction/get.js
@@ -15,7 +15,7 @@
  */
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
-import getAPIClient from '../../utils/api';
+import { getAPIClient } from '../../utils/api';
 import { query, queryNodeTransaction } from '../../utils/query';
 
 const TRANSACTION_STATES = ['unsigned', 'unprocessed'];

--- a/src/commands/transaction/sign.js
+++ b/src/commands/transaction/sign.js
@@ -13,14 +13,14 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import transactions from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
 import { getStdIn } from '../../utils/input/utils';
 import { ValidationError } from '../../utils/error';
-import parseTransactionString from '../../utils/transactions';
-import getInputsFromSources from '../../utils/input';
-import commonFlags from '../../utils/flags';
+import { parseTransactionString } from '../../utils/transactions';
+import { getInputsFromSources } from '../../utils/input';
+import { flags as commonFlags } from '../../utils/flags';
 
 const getTransactionInput = async () => {
 	try {

--- a/src/commands/transaction/verify.js
+++ b/src/commands/transaction/verify.js
@@ -13,10 +13,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import transactions from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
-import parseTransactionString from '../../utils/transactions';
+import { parseTransactionString } from '../../utils/transactions';
 import { getStdIn, getData } from '../../utils/input/utils';
 import { ValidationError } from '../../utils/error';
 

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,4 +1,6 @@
 import { APIClient } from '@liskhq/lisk-api-client';
+// tslint:disable-next-line no-submodule-imports
+import { NodeResource } from '@liskhq/lisk-api-client/dist-node/resources/node';
 
 /*
  * LiskHQ/lisk-commander
@@ -86,9 +88,9 @@ export const query = async (
 				);
 
 export const queryNodeTransaction =
-	async (client: APIClient, txnState: string, parameters: QueryParameter | ReadonlyArray<QueryParameter>): Promise<unknown> =>
+	async (client: NodeResource, txnState: string, parameters: ReadonlyArray<QueryParameter>): Promise<unknown> =>
 		Promise.all(
-			parameters.map(param =>
+			parameters.map(async (param: QueryParameter) =>
 				client
 					.getTransactions(txnState, param.query)
 					.then(res =>

--- a/test/utils/query.ts
+++ b/test/utils/query.ts
@@ -16,7 +16,6 @@
 import { expect } from 'chai';
 import { query, queryNodeTransaction } from '../../src/utils/query';
 import { APIClient } from '@liskhq/lisk-api-client';
-import { ApiResponse } from '@liskhq/lisk-api-client/dist-node/api_types';
 
 describe('query utils', () => {
 	const defaultEndpoint = 'accounts';
@@ -41,13 +40,7 @@ describe('query utils', () => {
 		},
 	];
 
-	interface MockAPIClient {
-		readonly accounts: {
-			get: () => ApiResponse;
-		};
-	}
-
-	let apiClient: MockAPIClient;
+	let apiClient: APIClient;
 	let response: {
 		readonly data?: unknown;
 		readonly no?: string;
@@ -63,7 +56,7 @@ describe('query utils', () => {
 				accounts: {
 					get: sandbox.stub().resolves(response),
 				},
-			};
+			} as any;
 			queryResult = query(
 				(apiClient as unknown) as APIClient,
 				defaultEndpoint,
@@ -93,13 +86,13 @@ describe('query utils', () => {
 				accounts: {
 					get: sandbox.stub().resolves(response),
 				},
-			};
+			} as any;
 			return Promise.resolve();
 		});
 
 		it('should call API client and should reject with an error', () => {
 			queryResult = query(
-				(apiClient as unknown) as APIClient,
+				apiClient,
 				defaultEndpoint,
 				defaultParameters,
 			);
@@ -122,7 +115,7 @@ describe('query utils', () => {
 				placeholder,
 			};
 			queryResult = query(
-				(apiClient as unknown) as APIClient,
+				apiClient,
 				defaultEndpoint,
 				paramWithPlaceholder,
 			);
@@ -148,9 +141,9 @@ describe('query utils', () => {
 				accounts: {
 					get: sandbox.stub().resolves(response),
 				},
-			};
+			} as any;
 			queryResult = query(
-				(apiClient as unknown) as APIClient,
+				apiClient,
 				defaultEndpoint,
 				defaultParameters,
 			);
@@ -184,7 +177,7 @@ describe('query utils', () => {
 				accounts: {
 					get: sandbox.stub().resolves(response),
 				},
-			};
+			} as any;
 			queryResult = query(apiClient, defaultEndpoint, defaultParameters);
 			return Promise.resolve();
 		});
@@ -209,9 +202,9 @@ describe('query utils', () => {
 				accounts: {
 					get: sandbox.stub().resolves(response),
 				},
-			};
+			} as any;
 			queryResult = query(
-				(apiClient as unknown) as APIClient,
+				apiClient,
 				defaultEndpoint,
 				defaultParameters,
 			);
@@ -239,9 +232,9 @@ describe('query utils', () => {
 				accounts: {
 					get: sandbox.stub().resolves(response),
 				},
-			};
+			} as any;
 			query(
-				(apiClient as unknown) as APIClient,
+				apiClient,
 				defaultEndpoint,
 				defaultArrayParameters,
 			);
@@ -285,7 +278,7 @@ describe('query utils', () => {
 				node: {
 					getTransactions: sandbox.stub().resolves(response),
 				},
-			};
+			} as any;
 			queryResult = queryNodeTransaction(
 				apiClient.node,
 				txnState,
@@ -335,7 +328,7 @@ describe('query utils', () => {
 				node: {
 					getTransactions: sandbox.stub().resolves(response),
 				},
-			};
+			} as any;
 			queryResult = queryNodeTransaction(
 				apiClient.node,
 				txnState,

--- a/test/utils/query.ts
+++ b/test/utils/query.ts
@@ -58,7 +58,7 @@ describe('query utils', () => {
 				},
 			} as any;
 			queryResult = query(
-				(apiClient as unknown) as APIClient,
+				apiClient,
 				defaultEndpoint,
 				defaultParameters,
 			);


### PR DESCRIPTION
### What was the problem?
Update lisk-elements to 2.0 for TypeScript support.

### How did I fix it?
Update the elements related package version and fix the imports


### Review checklist

* The PR resolves #676 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
